### PR TITLE
Update default selectable value in editor preview

### DIFF
--- a/PxGraf.Frontend/src/components/SelectableVariableMenus/SelectableVariableMenus.test.tsx
+++ b/PxGraf.Frontend/src/components/SelectableVariableMenus/SelectableVariableMenus.test.tsx
@@ -1,18 +1,68 @@
 import { render } from '@testing-library/react';
-import { IMenuProps, SelectableVariableMenus } from './SelectableVariableMenus';
+import { IMenuProps, SelectableVariableMenus, ISelectionState } from './SelectableVariableMenus';
 import React from 'react';
 import { IQueryVisualizationResponse } from '@statisticsfinland/pxvisualizer';
 import { EVariableType } from '@statisticsfinland/pxvisualizer';
 import { IVisualizationSettings } from 'types/visualizationSettings';
 import { VisualizationType } from 'types/visualizationType';
 import UiLanguageContext from 'contexts/uiLanguageContext';
+import { getSelections } from './SelectableVariableMenus';
+import { ISelectabilityInfo } from '../Preview/Preview';
+import { VariableType } from 'types/cubeMeta'; 
 
 const mockSetSelections = jest.fn((selections: IMenuProps | ((prevState: IMenuProps) => IMenuProps)) => {
     return;
 });
 
+const mockSelectables: ISelectabilityInfo[] = [
+    {
+        variable: {
+            code: "foobar1",
+            name: { fi: "foo1", sv: "bar1", en: "foobar1" },
+            note: { fi: "föö1", sv: "bär1", en: "fööbär1" },
+            type: VariableType.OtherClassificatory,
+            values: [{
+                code: "barfoo1",
+                name: { fi: "fyy1", sv: "bör1", en: "fyybör1" },
+                note: { fi: "fuu1", sv: "baar1", en: "fuubaar1" },
+                isSum: false,
+                contentComponent: null,
+            }, {
+                code: "barfoo2",
+                name: { fi: "fyy2", sv: "bör2", en: "fyybör2" },
+                note: { fi: "fuu2", sv: "baar2", en: "fuubaar2" },
+                isSum: false,
+                contentComponent: null,
+            }],
+        },
+        multiselectable: false,
+    },
+    {
+        variable: {
+            code: "foobar2",
+            name: { fi: "foo2", sv: "bar2", en: "foobar2" },
+            note: { fi: "föö2", sv: "bär2", en: "fööbär2" },
+            type: VariableType.OtherClassificatory,
+            values: [{
+                code: "barfoo1",
+                name: { fi: "fyy1", sv: "bör1", en: "fyybör1" },
+                note: { fi: "fuu1", sv: "baar1", en: "fuubaar1" },
+                isSum: false,
+                contentComponent: null,
+            }, {
+                code: "barfoo2",
+                name: { fi: "fyy2", sv: "bör2", en: "fyybör2" },
+                note: { fi: "fuu2", sv: "baar2", en: "fuubaar2" },
+                isSum: false,
+                contentComponent: null,
+            }],
+        },
+        multiselectable: false,
+    }
+]
+
 const mockVisualizationSettings: IVisualizationSettings = {
-    defaultSelectableVariableCodes: { "key": ["value"] },
+    defaultSelectableVariableCodes: { "foobar1": ["barfoo2"] },
     pivotRequested: false,
     cutYAxis: false,
     multiselectableVariableCode: "someCode",
@@ -93,5 +143,73 @@ describe('Rendering test', () => {
             </UiLanguageContext.Provider>
         );
         expect(asFragment()).toMatchSnapshot();
+    });
+});
+
+describe('Assertion tests', () => {
+    it('applies default selectable variable value if selections have not been manually changed', () => {
+        const initialSelectionState = {
+            activeSelections: {},
+            visualization: 'HorizontalBarChart',
+            multiselect: null,
+            manuallyChanged: {},
+        };
+
+        const selections = getSelections(
+            mockSelectables,
+            'HorizontalBarChart',
+            mockVisualizationSettings,
+            initialSelectionState,
+            jest.fn()
+        )
+
+        expect(selections['foobar1']).toEqual(mockVisualizationSettings.defaultSelectableVariableCodes['foobar1']);
+    });
+
+    it('applies first available variable value if default value has not been set', () => {
+        const initialSelectionState = {
+            activeSelections: {},
+            visualization: 'HorizontalBarChart',
+            multiselect: null,
+            manuallyChanged: {},
+        };
+
+        const selections = getSelections(
+            mockSelectables,
+            'HorizontalBarChart',
+            mockVisualizationSettings,
+            initialSelectionState,
+            jest.fn()
+        )
+
+        const foobar2Var = mockData.metaData[1];
+
+        expect(selections[foobar2Var.code]).toEqual([foobar2Var.values[0].code]);
+    });
+
+    it('retains manually changed selections over default selectable variable values', () => {
+        const initialSelectionState: ISelectionState = {
+            activeSelections: {
+                'foobar1': ['barfoo1'],
+                'foobar2': ['barfoo2'],
+            },
+            visualization: 'HorizontalBarChart',
+            multiselect: "someCode",
+            manuallyChanged: {
+                'foobar1': true,
+                'foobar2': true,
+            },
+        };
+
+        const selections = getSelections(
+            mockSelectables,
+            "HorizontalBarChart",
+            mockVisualizationSettings,
+            initialSelectionState,
+            jest.fn(),
+        )
+
+        expect(selections['foobar1']).toEqual(['barfoo1']);
+        expect(selections['foobar2']).toEqual(['barfoo2']);
     });
 });

--- a/PxGraf.Frontend/src/components/SelectableVariableMenus/SelectableVariableMenus.tsx
+++ b/PxGraf.Frontend/src/components/SelectableVariableMenus/SelectableVariableMenus.tsx
@@ -14,6 +14,7 @@ export interface ISelectionState {
     activeSelections: IMenuProps;
     visualization: string;
     multiselect: string;
+    manuallyChanged?: { [key: string]: boolean };
 }
 
 interface ISelectableVariableMenusProps {
@@ -44,22 +45,23 @@ export const getSelections = (
     selectedVisualization: string,
     visualizationSettings: IVisualizationSettings,
     state: ISelectionState,
-    setState: Dispatch<SetStateAction<ISelectionState>>
+    setState: Dispatch<SetStateAction<ISelectionState>>,
 ) => {
     const newState: ISelectionState = {
         activeSelections: {},
         visualization: selectedVisualization,
-        multiselect: visualizationSettings?.multiselectableVariableCode
+        multiselect: visualizationSettings?.multiselectableVariableCode,
+        manuallyChanged: { ...state.manuallyChanged },
     };
-
     selectables.forEach(({ variable, multiselectable }) => {
         const { code } = variable;
-
+        const defaultSelection = visualizationSettings?.defaultSelectableVariableCodes?.[code];
         if (newState.visualization !== state.visualization
             || newState.multiselect !== state.multiselect
             || state.activeSelections[code] == null
-            || state.activeSelections[code].length === 0) {
-            newState.activeSelections[code] = [variable.values[0].code];
+            || state.activeSelections[code].length === 0
+            || !state.manuallyChanged?.[code]) {
+                newState.activeSelections[code] = defaultSelection || [variable.values[0].code];
         } else {
             newState.activeSelections[code] = multiselectable
                 ? state.activeSelections[code]
@@ -77,13 +79,22 @@ export const SelectableVariableMenus: React.FC<ISelectableVariableMenusProps> = 
     const [selectionState, setSelectionState] = useState<ISelectionState>({ activeSelections: null, visualization: null, multiselect: null });
 
     const selectables = getSelectables(data, visualizationSettings);
-    const selections = getSelections(selectables, selectedVisualization, visualizationSettings, selectionState, setSelectionState);
+    const selections = getSelections(selectables, selectedVisualization, visualizationSettings, selectionState, setSelectionState );
+    const onValueChanged = (newSelections, code) => setSelectionState(prevState => ({
+        ...prevState,
+        activeSelections: {
+            ...prevState.activeSelections,
+            [code]: newSelections[code],
+        },
+        manuallyChanged: {
+            ...prevState.manuallyChanged,
+            [code]: true, 
+        },
+    }));
 
     useEffect(() => {
         setSelections(selections);
     }, [selectionState]);
-
-    const onValueChanged = (newSelections) => setSelectionState({ ...selectionState, activeSelections: newSelections as IMenuProps });
 
     return (
         <Stack direction="row" spacing={2}>
@@ -100,7 +111,7 @@ export const SelectableVariableMenus: React.FC<ISelectableVariableMenusProps> = 
                                 [v.variable.code]: typeof value === 'string'
                                     ? value.split(',')
                                     : value
-                            })
+                            }, v.variable.code)
                         }
                     }}
                 />

--- a/PxGraf.Frontend/src/components/SelectableVariableMenus/__snapshots__/SelectableVariableMenus.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/SelectableVariableMenus/__snapshots__/SelectableVariableMenus.test.tsx.snap
@@ -28,14 +28,14 @@ exports[`Rendering test renders correctly 1`] = `
           role="combobox"
           tabindex="0"
         >
-          fyy1
+          fyy2
         </div>
         <input
           aria-hidden="true"
           aria-invalid="false"
           class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
           tabindex="-1"
-          value="barfoo1"
+          value="barfoo2"
         />
         <svg
           aria-hidden="true"


### PR DESCRIPTION
If default value for a selectable variable has been assigned and no overriding value has been picked in the preview, editor now uses default value for the preview.
Added tests to cover changes.