### PR TITLE
Replaced broken length based relative path with Path.GetRelativePath()

### DIFF
--- a/PxGraf/Datasource/FileDatasource/LocalFilesystemDatabase.cs
+++ b/PxGraf/Datasource/FileDatasource/LocalFilesystemDatabase.cs
@@ -48,7 +48,7 @@ namespace PxGraf.Datasource.FileDatasource
             string path = PathUtils.BuildAndSanitizePath(config.DatabaseRootPath, groupHierarcy);
             foreach (string pxFile in Directory.EnumerateFiles(path, PxSyntaxConstants.PX_FILE_FILTER))
             {
-                tables.Add(new PxTableReference(pxFile.Remove(0, config.DatabaseRootPath.Length)));
+                tables.Add(new PxTableReference(Path.GetRelativePath(config.DatabaseRootPath, pxFile)));
             }
             return tables;
         }

--- a/PxGraf/PxGraf.csproj
+++ b/PxGraf/PxGraf.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>PxGraf</AssemblyName>
     <UserSecretsId>5fefcbdc-e04e-4475-9927-aab412b027ff</UserSecretsId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>4.0.00</VersionPrefix>
+    <VersionPrefix>4.0.1</VersionPrefix>
 	<SpaRoot>..\PxGraf.Frontend</SpaRoot>
 	<Configurations>Debug;Release;Test</Configurations>
   </PropertyGroup>


### PR DESCRIPTION
Fixed a bug where the path length was used for generating relative paths. This caused issued when there were additional escape characters in the path strings.