### PR TITLE
Description field of the sq meta object is always set to null

### DIFF
--- a/PxGraf/Controllers/QueryMetaController.cs
+++ b/PxGraf/Controllers/QueryMetaController.cs
@@ -53,7 +53,7 @@ namespace PxGraf.Controllers
                     Selectable = savedQuery.Query.DimensionQueries.Any(q => q.Value.Selectable),
                     VisualizationType = savedQuery.Settings.VisualizationType,
                     TableId = savedQuery.Query.TableReference.Name,
-                    Description = filteredMeta.GetMatrixMultilanguageProperty(PxSyntaxConstants.NOTE_KEY),
+                    Description = null, // This is kept here for compatibility with the old version, but we currently don't have a description for saved queries
                     TableReference = savedQuery.Query.TableReference,
                     LastUpdated = PxSyntaxConstants.FormatPxDateTime(filteredMeta.GetContentDimension().Values.Map(cdv => cdv.LastUpdated).Max())
                 };

--- a/PxGraf/PxGraf.csproj
+++ b/PxGraf/PxGraf.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>PxGraf</AssemblyName>
     <UserSecretsId>5fefcbdc-e04e-4475-9927-aab412b027ff</UserSecretsId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>4.0.3</VersionPrefix>
+    <VersionPrefix>4.0.4</VersionPrefix>
 	<SpaRoot>..\PxGraf.Frontend</SpaRoot>
 	<Configurations>Debug;Release;Test</Configurations>
   </PropertyGroup>

--- a/UnitTests/ControllerTests/QueryMetaControllerTests/GetQueryMetaTests.cs
+++ b/UnitTests/ControllerTests/QueryMetaControllerTests/GetQueryMetaTests.cs
@@ -69,7 +69,7 @@ namespace UnitTests.ControllerTests.QueryMetaControllerTests
             Assert.That(result.Value.Selectable, Is.False);
             Assert.That(result.Value.VisualizationType, Is.EqualTo(VisualizationType.LineChart));
             Assert.That(result.Value.TableId, Is.EqualTo("TestPxFile.px"));
-            Assert.That(result.Value.Description["fi"], Is.EqualTo("Test note"));
+            Assert.That(result.Value.Description, Is.Null);
             Assert.That(result.Value.LastUpdated, Is.EqualTo("2009-09-01T00:00:00Z"));
             Assert.That(result.Value.TableReference.Name, Is.EqualTo("TestPxFile.px"));
 
@@ -154,7 +154,7 @@ namespace UnitTests.ControllerTests.QueryMetaControllerTests
             Assert.That(result.Value.Selectable, Is.False);
             Assert.That(result.Value.VisualizationType, Is.EqualTo(VisualizationType.LineChart));
             Assert.That(result.Value.TableId, Is.EqualTo("TestPxFile.px"));
-            Assert.That(result.Value.Description["fi"], Is.EqualTo("Test note"));
+            Assert.That(result.Value.Description, Is.Null);
             Assert.That(result.Value.LastUpdated, Is.EqualTo("2009-09-01T00:00:00Z"));
             Assert.That(result.Value.TableReference.Name, Is.EqualTo("TestPxFile.px"));
 


### PR DESCRIPTION
We currently have no relevant information to put to the description field of the sq meta api endpoint.