### PR TITLE
Bug: Tables were identified by the table id, not filename

### DIFF
--- a/PxGraf.Frontend/.eslintignore
+++ b/PxGraf.Frontend/.eslintignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/PxGraf.Frontend/.eslintrc.json
+++ b/PxGraf.Frontend/.eslintrc.json
@@ -1,22 +1,23 @@
 {
-    "env": {
-        "browser": true,
-        "es2021": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:react/recommended"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
-    "plugins": [
-        "@typescript-eslint",
-        "react"
-    ],
-    "rules": {
-    }
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": [
+    "@typescript-eslint",
+    "react"
+  ],
+  "rules": {
+  },
+  "ignorePatterns": [ "node_modules/" ]
 }

--- a/PxGraf.Frontend/package-lock.json
+++ b/PxGraf.Frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pxgraf",
-  "version": "2.0.46",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pxgraf",
-      "version": "2.0.46",
+      "version": "2.1.1",
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
@@ -43,6 +43,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.7",
         "jest": "^29.7.0",
+        "jest-editor-support": "^32.0.0-beta.1",
         "jest-environment-jsdom": "^29.7.0",
         "jest-junit": "^16.0.0",
         "jest-sonar-reporter": "^2.0.0",
@@ -192,6 +193,46 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+      "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
@@ -229,6 +270,19 @@
       "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1659,6 +1713,30 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-eoV3sjS1M5k3YdrFWezqdndfgepwB86gwyXC0BzV2saZdJ42ySUoEDBGKuwta8A6Zh3w8tVHNFxz1BqiFraHCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.0-alpha.6"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-XcsAVaqc69QyMz1/FChyhWSoAMaKcDPhFOuWJz/H51LppsyZRAJPXkPnMopsS+qfut8cggExr9QLcsYaX6hqqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
     "node_modules/@jest/reporters": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
@@ -1715,6 +1793,61 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-iDtIFCyRT8ZyLmz6kYbS8GR/MBXKA6uZPBfdTcnd2y0T987DV3GVlvwkAC+iFTc1w3HgwQe8LTf+y3i+O2ISCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.0-alpha.6",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils/node_modules/@jest/schemas": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-Ukr3kR/VsBq8+JHU92xArhSJeFQHVHs5T1laPO00GrrNzv3DvoHn3/EVVagGn9CHbLeAyJHXFRHYxq3+520kiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.33.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils/node_modules/@jest/types": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-qUjAm8uvIR7oExn/Fp7/bvn58HSZng5itQDM9x0vaxXWxxGH/8MDmqX/h7OUBz9ka+KfYRaTxe4Y6wiM8+nphw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.0-alpha.6",
+        "@jest/schemas": "30.0.0-alpha.6",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils/node_modules/@sinclair/typebox": {
+      "version": "0.33.22",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.22.tgz",
+      "integrity": "sha512-auUj4k+f4pyrIVf4GW5UKquSZFHJWri06QgARy9C0t9ZTjJLIuNIrr1yl9bWcJWJ1Gz1vOvYN1D+QPaIlNMVkQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jest/source-map": {
       "version": "29.6.3",
@@ -2123,6 +2256,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@popperjs/core": {
@@ -7106,6 +7252,558 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jest-editor-support": {
+      "version": "32.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/jest-editor-support/-/jest-editor-support-32.0.0-beta.1.tgz",
+      "integrity": "sha512-IimucoTLZXwR1+1YEeqc++XjYRxffCEfr+uRlfwuVC5LiyIYUmPqo5x+f6EMkohUMOyQMICB5tEohrDw9smL1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/traverse": "7.23.2",
+        "@babel/types": "^7.20.7",
+        "@jest/snapshot-utils": "^30.0.0-alpha.5",
+        "@jest/test-result": "^29.3.1",
+        "@jest/types": "^29.3.1",
+        "jest-snapshot": "^30.0.0-alpha.5"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/@babel/traverse": {
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/@jest/expect-utils": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-QMySMhaCUl0ZQd7Tx5X3fVWY5jtQxZNrTll0OyavdQ70ZTLgk0kU9K+XovcMWO26MK9R5EX7bBgD/j7w9hUM4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "30.0.0-alpha.6"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/@jest/schemas": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-Ukr3kR/VsBq8+JHU92xArhSJeFQHVHs5T1laPO00GrrNzv3DvoHn3/EVVagGn9CHbLeAyJHXFRHYxq3+520kiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.33.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/@jest/transform": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-4L8BZm38BJASswsqruc4c3F0AExYLvp0xq8067e7fIyg4hfwa4zUA+N2idf+eTTjDWevVVdIBfELzJ8b7nvO4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "30.0.0-alpha.6",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^7.0.0",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "30.0.0-alpha.6",
+        "jest-regex-util": "30.0.0-alpha.6",
+        "jest-util": "30.0.0-alpha.6",
+        "micromatch": "^4.0.7",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/@jest/transform/node_modules/@jest/types": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-qUjAm8uvIR7oExn/Fp7/bvn58HSZng5itQDM9x0vaxXWxxGH/8MDmqX/h7OUBz9ka+KfYRaTxe4Y6wiM8+nphw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.0-alpha.6",
+        "@jest/schemas": "30.0.0-alpha.6",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/@sinclair/typebox": {
+      "version": "0.33.22",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.22.tgz",
+      "integrity": "sha512-auUj4k+f4pyrIVf4GW5UKquSZFHJWri06QgARy9C0t9ZTjJLIuNIrr1yl9bWcJWJ1Gz1vOvYN1D+QPaIlNMVkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-editor-support/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/babel-plugin-istanbul": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.0.tgz",
+      "integrity": "sha512-C5OzENSx/A+gt7t4VH1I2XsflxyPUmXRFPKBxt33xncdOmq7oROVM3bZv9Ysjjkv8OJYDMa+tKuKMvqU/H3xdw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/ci-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
+      "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-editor-support/node_modules/diff-sequences": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-DVGt3/yzbneMUTuupsMqyfSXMnU2fE0lVsC9uFsJmRpluvSi7ZhrS0GX5tnMna6Ta788FGfOUx+irI/+cAZ4EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/expect": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-WVi2V4iHKw/vHEyye00Q9CSZz7KHDbJkJyteUI8kTih9jiyMl3bIk7wLYFcY9D1Blnadlyb5w5NBuNjQBow99g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.0.0-alpha.6",
+        "jest-get-type": "30.0.0-alpha.6",
+        "jest-matcher-utils": "30.0.0-alpha.6",
+        "jest-message-util": "30.0.0-alpha.6",
+        "jest-mock": "30.0.0-alpha.6",
+        "jest-util": "30.0.0-alpha.6"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-diff": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-43j1DoYwVKrkbB67a2gC0ijjIY9biF0JSPXv7H6zlOkzNlqYg8hSDzrurLNo6zGKatW4JSBLE79LmXPJPj1m6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "30.0.0-alpha.6",
+        "jest-get-type": "30.0.0-alpha.6",
+        "pretty-format": "30.0.0-alpha.6"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-get-type": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-lJEoQdCY4ICN6+T0lJ9BODKuqPOEpCv2NnJsEO1nmsK0fbWZmN/pgOPHVqLfK8i3jZpUmgupJ1w8r36mc8iiBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-haste-map": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-NR/Kw8HyOkuWIdT8ynsp9KnsTDvWnlz8WSOmtQxySTIzOWbZaeJ2FJi9LoDL6+vhKpdlLfUvhgZVtnFJSLCzew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.0-alpha.6",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "30.0.0-alpha.6",
+        "jest-util": "30.0.0-alpha.6",
+        "jest-worker": "30.0.0-alpha.6",
+        "micromatch": "^4.0.7",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-haste-map/node_modules/@jest/types": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-qUjAm8uvIR7oExn/Fp7/bvn58HSZng5itQDM9x0vaxXWxxGH/8MDmqX/h7OUBz9ka+KfYRaTxe4Y6wiM8+nphw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.0-alpha.6",
+        "@jest/schemas": "30.0.0-alpha.6",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-matcher-utils": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-jaq7+HznsK54G0qzu96ZwfMEKHmlPiDqg6qG2p/hVQzr6Y/qVMRh8abI9Y1lX6SSXkr+S9mPAkmOsuJNLTLYmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "30.0.0-alpha.6",
+        "jest-get-type": "30.0.0-alpha.6",
+        "pretty-format": "30.0.0-alpha.6"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-message-util": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-XAGJqkrBo7m3bFxWqiNqL0PyAWGf1XHR6bTve90MjBKJuIzhJsounGTzBNUw8JoU7Uzcj5Z6ZmEhaE3CDnwjfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "30.0.0-alpha.6",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.7",
+        "pretty-format": "30.0.0-alpha.6",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-message-util/node_modules/@jest/types": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-qUjAm8uvIR7oExn/Fp7/bvn58HSZng5itQDM9x0vaxXWxxGH/8MDmqX/h7OUBz9ka+KfYRaTxe4Y6wiM8+nphw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.0-alpha.6",
+        "@jest/schemas": "30.0.0-alpha.6",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-mock": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-ezW02IXiKyFYAgDuxfAlONWULitSaB66t411fq2BJxQtgyMGtv59CsnhgbKb0gQp+9vig5MO5ytDCUPalTbarg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.0-alpha.6",
+        "@types/node": "*",
+        "jest-util": "30.0.0-alpha.6"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-mock/node_modules/@jest/types": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-qUjAm8uvIR7oExn/Fp7/bvn58HSZng5itQDM9x0vaxXWxxGH/8MDmqX/h7OUBz9ka+KfYRaTxe4Y6wiM8+nphw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.0-alpha.6",
+        "@jest/schemas": "30.0.0-alpha.6",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-regex-util": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-XcsAVaqc69QyMz1/FChyhWSoAMaKcDPhFOuWJz/H51LppsyZRAJPXkPnMopsS+qfut8cggExr9QLcsYaX6hqqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-snapshot": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-YCBUxSNJ9YGch3tyQdxQkOUitbmXahHL6UhSQeSMERFfX1UMrHyEDHggglocCUg4G3jdU8YzshxOJ/oaR6Ph8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "30.0.0-alpha.6",
+        "@jest/snapshot-utils": "30.0.0-alpha.6",
+        "@jest/transform": "30.0.0-alpha.6",
+        "@jest/types": "30.0.0-alpha.6",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "30.0.0-alpha.6",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "30.0.0-alpha.6",
+        "jest-get-type": "30.0.0-alpha.6",
+        "jest-matcher-utils": "30.0.0-alpha.6",
+        "jest-message-util": "30.0.0-alpha.6",
+        "jest-util": "30.0.0-alpha.6",
+        "pretty-format": "30.0.0-alpha.6",
+        "semver": "^7.5.3",
+        "synckit": "^0.9.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-snapshot/node_modules/@jest/types": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-qUjAm8uvIR7oExn/Fp7/bvn58HSZng5itQDM9x0vaxXWxxGH/8MDmqX/h7OUBz9ka+KfYRaTxe4Y6wiM8+nphw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.0-alpha.6",
+        "@jest/schemas": "30.0.0-alpha.6",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-util": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-JlimakOVDyoMC8TEG+knoufxUqLG+Btihf1G8o5sHxz54C6oL54Wetfepp+Nhuj/1hSL0sQtkovvjlEycf9i0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.0-alpha.6",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-util/node_modules/@jest/types": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-qUjAm8uvIR7oExn/Fp7/bvn58HSZng5itQDM9x0vaxXWxxGH/8MDmqX/h7OUBz9ka+KfYRaTxe4Y6wiM8+nphw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.0-alpha.6",
+        "@jest/schemas": "30.0.0-alpha.6",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/jest-worker": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-qlzX7zFT/QdUV/LWsJwZBlaIBaJ+E2VH3d1gArGVP+9hUHGpJkEzCSBK7yuZrkt+M/U0Jre5+maPRmkinEF4DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.2.0",
+        "jest-util": "30.0.0-alpha.6",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/pretty-format": {
+      "version": "30.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.0-alpha.6.tgz",
+      "integrity": "sha512-xkeffkZoqQmRrcNewpOsUCKNOl+CkPqjt3Ld749uz1S7/O7GuPNPv2fZk3v/1U/FE8/B4Zz0llVL80MKON1tOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.0-alpha.6",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-editor-support/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/jest-environment-jsdom": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
@@ -10024,6 +10722,23 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/synckit": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
+      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/PxGraf.Frontend/package.json
+++ b/PxGraf.Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxgraf",
-  "version": "2.0.46",
+  "version": "2.1.1",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.4",
@@ -34,6 +34,18 @@
     "reportFile": "test-reporter.xml",
     "indent": 4
   },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "jsdom",
+    "testPathIgnorePatterns": [
+      "/node_modules/"
+    ],
+    "globals": {
+      "ts-jest": {
+        "tsconfig": "./tsconfig.json"
+      }
+    }
+  },
   "browserslist": {
     "production": [
       ">0.2%",
@@ -63,6 +75,7 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
     "jest": "^29.7.0",
+    "jest-editor-support": "^32.0.0-beta.1",
     "jest-environment-jsdom": "^29.7.0",
     "jest-junit": "^16.0.0",
     "jest-sonar-reporter": "^2.0.0",

--- a/PxGraf.Frontend/src/api/services/table.ts
+++ b/PxGraf.Frontend/src/api/services/table.ts
@@ -3,42 +3,7 @@
 import ApiClient from "api/client";
 import { useQuery } from "react-query";
 import { defaultQueryOptions } from "utils/ApiHelpers";
-import { MultiLanguageString } from "../../types/multiLanguageString";
-
-/**
- * Interface for a table list response.
- * @property {string} id - The id of the table.
- * @property {string} type - The type of the table where 't' is a table and 'l' is a list item.
- * @property {string} updated - The last updated date of the table.
- * @property {MultiLanguageString} text - The description of the table as a multi-language string.
- * @property {string[]} languages - Available languages of the table.
- */
-export interface IDatabaseGroupContents {
-    headers: IDatabaseGroupHeader[];
-    files: IDatabaseTable[];
-}
-
-/***
- * Interface for a table group header
- * @property {string} code - The code of the table group.
- * @property {MultiLanguageString} name - The name of the table group as a multi-language string.
- * @property {string[]} languages - Available languages of the table group.
- */
-export interface IDatabaseGroupHeader {
-    code: string;
-    name: MultiLanguageString;
-    languages: string[];
-}
-
-/***
- * Interface for a px table
- * @property {string} lastUpdated - The last updated date of the table.
- * @property {boolean} error - Flag to indicate if there's an error with the table.
- */
-export interface IDatabaseTable extends IDatabaseGroupHeader {
-    lastUpdated: string | null;
-    error?: boolean;
-}
+import { IDatabaseGroupContents } from "types/tableListItems";
 
 /**
  * Interface for a table result.

--- a/PxGraf.Frontend/src/components/DirectoryInfo/DirectoryInfo.test.tsx
+++ b/PxGraf.Frontend/src/components/DirectoryInfo/DirectoryInfo.test.tsx
@@ -1,16 +1,14 @@
 import { render, screen } from '@testing-library/react';
-import { DirectoryInfo } from './DirectoryInfo';
 import React from 'react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import UiLanguageContext from 'contexts/uiLanguageContext';
-import { IDatabaseTable } from '../../api/services/table';
-import { BasePath } from '../../envVars';
+import { IDatabaseGroupHeader } from 'types/tableListItems';
+import DirectoryInfo from './DirectoryInfo';
 
 const mockPath = 'asd123';
-const mockItem: IDatabaseTable = {
-    code: 'id',
-    lastUpdated: '01.01.2000',
+const mockItem: IDatabaseGroupHeader = {
+    code : 'foo-group',
     name: { 'fi': 'foo1-fi', 'en': 'foo1-en', 'sv': 'foo1-sv' },
     languages: ['fi', 'en', 'sv']
 };
@@ -36,7 +34,6 @@ jest.mock('react-i18next', () => ({
 jest.mock('api/services/table', () => ({
     ...jest.requireActual('api/services/table'),
     useTableQuery: () => {
-
         return mockItem;
     },
 }));
@@ -67,7 +64,7 @@ describe('Rendering test', () => {
 
 describe('Assertion tests', () => {
     it('should contain a specific link with a specific text', () => {
-        const expectedHref = '/table-list/a/s/d/1/2/3/id/';
+        const expectedHref = '/table-list/a/s/d/1/2/3/foo-group/';
         render(<MemoryRouter><DirectoryInfo path={mockPath} item={mockItem} /></MemoryRouter>);
         expect(screen.getByText(mockItem.name[language])).toBeInTheDocument();
         expect(screen.getByRole('link').getAttribute('href')).toEqual(expectedHref);

--- a/PxGraf.Frontend/src/components/DirectoryInfo/DirectoryInfo.tsx
+++ b/PxGraf.Frontend/src/components/DirectoryInfo/DirectoryInfo.tsx
@@ -3,17 +3,12 @@ import { ListItemText, ListItemButton, Typography, Divider } from '@mui/material
 import { urls } from 'Router';
 import React from 'react';
 import { spacing } from 'utils/componentHelpers';
-import { MultiLanguageString } from "../../types/multiLanguageString";
 import { UiLanguageContext } from 'contexts/uiLanguageContext';
+import { IDatabaseGroupHeader } from 'types/tableListItems';
 
 interface IDirectoryInfoProps {
     path: string;
-    item: {
-        code?: string;
-        lastUpdated?: string;
-        name?: MultiLanguageString;
-        languages?: string[];
-    }
+    item: IDatabaseGroupHeader;
 }
 
 export const DirectoryInfo: React.FC<IDirectoryInfoProps> = ({ path, item }) => {
@@ -25,17 +20,9 @@ export const DirectoryInfo: React.FC<IDirectoryInfoProps> = ({ path, item }) => 
         <>
             <ListItemButton id="mainContent" component={Link} to={urls.tableList(currentPath)}>
                 <ListItemText primary={
-                    <>
-                        <Typography variant="body1" sx={{ ...spacing(1) }}>
-                            {item.name[displayLanguage]}
-                        </Typography>
-                        {
-                            item.lastUpdated &&
-                            <Typography variant="body2" sx={{ ...spacing(1) }}>
-                                {item.lastUpdated}
-                            </Typography>
-                        }
-                    </>
+                    <Typography variant="body1" sx={{ ...spacing(1) }}>
+                        {item.name[displayLanguage]}
+                    </Typography>
                 } />
             </ListItemButton>
             <Divider />

--- a/PxGraf.Frontend/src/components/DirectoryInfo/__snapshots__/DirectoryInfo.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/DirectoryInfo/__snapshots__/DirectoryInfo.test.tsx.snap
@@ -4,27 +4,18 @@ exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <a
     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-    href="/table-list/a/s/d/1/2/3/id/"
+    href="/table-list/a/s/d/1/2/3/foo-group/"
     id="mainContent"
     tabindex="0"
   >
     <div
       class="MuiListItemText-root css-tlelie-MuiListItemText-root"
     >
-      <span
-        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+      <p
+        class="MuiTypography-root MuiTypography-body1 css-x61gb3-MuiTypography-root"
       >
-        <p
-          class="MuiTypography-root MuiTypography-body1 css-x61gb3-MuiTypography-root"
-        >
-          foo1-fi
-        </p>
-        <p
-          class="MuiTypography-root MuiTypography-body2 css-1wjvmi0-MuiTypography-root"
-        >
-          01.01.2000
-        </p>
-      </span>
+        foo1-fi
+      </p>
     </div>
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"

--- a/PxGraf.Frontend/src/components/NestedList/NestedList.test.tsx
+++ b/PxGraf.Frontend/src/components/NestedList/NestedList.test.tsx
@@ -3,8 +3,9 @@ import { render } from '@testing-library/react';
 import UiLanguageContext from 'contexts/uiLanguageContext';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
-import { IDatabaseGroupContents, ITableResult } from '../../api/services/table';
 import NestedList from './NestedList';
+import { IDatabaseGroupContents } from 'types/tableListItems';
+import { ITableResult } from 'api/services/table';
 
 jest.mock('react-i18next', () => ({
     ...jest.requireActual('react-i18next'),
@@ -39,7 +40,7 @@ const mockDatabaseContents: IDatabaseGroupContents = {
     ],
     files: [
         {
-            code: 'asd2',
+            fileName: 'asd2.px',
             lastUpdated: '2021-11-13T14:53:06',
             name: { 'fi': 'foo2-fi', 'sv': 'foo2-sv' },
             languages: ['en', 'sv']

--- a/PxGraf.Frontend/src/components/NestedList/NestedList.tsx
+++ b/PxGraf.Frontend/src/components/NestedList/NestedList.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-
 import { ListItem, ListItemIcon, ListItemText, Divider, Skeleton, Alert } from '@mui/material';
-
 import UiLanguageContext from 'contexts/uiLanguageContext';
 import styled from 'styled-components';
-import { IDatabaseGroupHeader, IDatabaseTable, useTableQuery } from 'api/services/table';
 import { TableItem } from './TableItem';
 import { TableListItem } from './TableListItem';
 import useHierarchyParams from 'hooks/useHierarchyParams';
 import useScrollToElement from 'hooks/useScrollToElement';
-import { sortDatabaseGroups, sortDatabaseTables } from 'utils/sortingHelpers';
+import { useTableQuery } from 'api/services/table';
+import { IDatabaseGroupHeader, IDatabaseTable } from 'types/tableListItems';
+import { sortDatabaseItems } from 'utils/sortingHelpers';
 
 const StyledSkeleton = styled(Skeleton)`
   width: 24px;
@@ -25,6 +24,10 @@ const ErrorAlert = styled(Alert)`
   width: 100%;
 `;
 
+/**
+ * @property {string[]} path - Path to the current location in the tree.
+ * @property {number} depth - Current browsing depth.
+ */
 interface INestedListProps {
     path: string[];
     depth?: number;
@@ -33,8 +36,6 @@ interface INestedListProps {
 /**
  * Nested list component for displaying the database and table hierarchies.
  * @see TableListItem component is used for displaying databases and subfolders while @see {@link TableItem} component is used for displaying individual tables.
- * @param {string[]} path Path to the current location in the Px file system.
- * @param {number} depth Current browsing depth.
  */
 export const NestedList: React.FC<INestedListProps> = ({ path, depth }) => {
     const { language } = React.useContext(UiLanguageContext);
@@ -48,12 +49,12 @@ export const NestedList: React.FC<INestedListProps> = ({ path, depth }) => {
 
     const sortedGroups: IDatabaseGroupHeader[] = React.useMemo(() => {
         if (!data?.headers) return null;
-        return sortDatabaseGroups(data.headers, language);
+        return sortDatabaseItems(data.headers, language);
     }, [data, language]);
 
     const sortedTables: IDatabaseTable[] = React.useMemo(() => {
         if (!data?.files) return null;
-        return sortDatabaseTables(data.files, language);
+        return sortDatabaseItems(data.files, language);
     }, [data, language]);
 
     if (isLoading) {
@@ -92,8 +93,8 @@ export const NestedList: React.FC<INestedListProps> = ({ path, depth }) => {
             {
                 sortedTables ? sortedTables.map((item) => (
                     <TableItem
-                        key={`${item.code}-table-key`}
-                        currentPath={[...path, item.code]}
+                        key={`${item.fileName}-table-key`}
+                        currentPath={[...path, item.fileName]}
                         item={item}
                         depth={depth ?? 0}
                     />

--- a/PxGraf.Frontend/src/components/NestedList/TableItem.test.tsx
+++ b/PxGraf.Frontend/src/components/NestedList/TableItem.test.tsx
@@ -4,7 +4,7 @@ import UiLanguageContext from 'contexts/uiLanguageContext';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import { TableItem } from './TableItem';
-import { IDatabaseTable } from 'api/services/table';
+import { IDatabaseTable } from '../../types/tableListItems';
 
 jest.mock('react-i18next', () => ({
     ...jest.requireActual('react-i18next'),
@@ -25,7 +25,7 @@ jest.mock('envVars', () => ({
 }));
 
 const mockItem: IDatabaseTable = {
-    code: 'asd',
+    fileName: 'asd.px',
     lastUpdated: '2021-10-13T14:53:06',
     name: { 'fi': 'seppo', 'sv': 'seppo-sv' },
     languages: ['fi', 'sv']
@@ -73,7 +73,7 @@ describe('Assertion tests', () => {
 
     it('renders MUI alert when error property is true', async () => {
         const mockErrorItem: IDatabaseTable = {
-            code: 'error',
+            fileName: 'error',
             lastUpdated: null,
             name: { 'fi': 'error', 'sv': 'error-sv' },
             languages: ['fi', 'sv'],

--- a/PxGraf.Frontend/src/components/NestedList/TableItem.tsx
+++ b/PxGraf.Frontend/src/components/NestedList/TableItem.tsx
@@ -1,13 +1,13 @@
 import { Alert, AlertTitle, Divider, ListItem, ListItemButton, ListItemIcon, ListItemText } from "@mui/material";
 import FileIcon from '@mui/icons-material/InsertDriveFileOutlined';
-import { IDatabaseTable } from "api/services/table";
 import React from 'react';
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { urls } from "Router";
 import { UiLanguageContext } from "contexts/uiLanguageContext";
-import { parseLanguageString } from '../../utils/ApiHelpers';
+import { parseLanguageString } from 'utils/ApiHelpers';
+import { IDatabaseTable } from 'types/tableListItems';
 
 const StyledListItem = styled(ListItem)`
   background-color: #f8f8f8;
@@ -17,6 +17,11 @@ const ErrorAlert = styled(Alert)`
   width: 100%;
 `;
 
+/**
+ * @property {string[]} currentPath Path to the table in in the hierarchy of the table list.
+ * @property {IDatabaseTable} item Contains information about the table.
+ * @property {number} depth Current depth in the hierarchy of the table list.
+ */
 interface ITableItemProps {
     currentPath: string[];
     item: IDatabaseTable;
@@ -25,21 +30,18 @@ interface ITableItemProps {
 
 /**
  * Component used for displaying a table in @see {@link NestedList} component.
- * @param {string[]} currentPath Path to the table in the Px file system
- * @param {IDatabaseTable} item Response object that stores information about the database or subfolder.
- * @param {number} depth Current browsing depth.
  */
 export const TableItem: React.FC<ITableItemProps> = ({ currentPath, item, depth }) => {
     const { t } = useTranslation();
     const { language } = React.useContext(UiLanguageContext);
     const displayLanguage = item.languages.includes(language) ? language : item.languages[0];
 
-    return <React.Fragment key={`${item.code}-key`}>
+    return <React.Fragment key={`${item.fileName}-key`}>
         <StyledListItem id={currentPath.join('-')}>
             <ListItemButton sx={{ mr: 3, pl: depth * 4 }} component={Link} to={urls.editor(currentPath)}>
                 {item.error ?
                     <ErrorAlert sx={{ pl: depth * 4 }} severity="warning">
-                        <AlertTitle>{`${item.name[displayLanguage] ?? item.code}`}</AlertTitle>
+                        <AlertTitle>{`${item.name[displayLanguage] ?? item.fileName}`}</AlertTitle>
                         {t("error.contentVariableMissing")}
                     </ErrorAlert>
                     :

--- a/PxGraf.Frontend/src/components/NestedList/TableListItem.test.tsx
+++ b/PxGraf.Frontend/src/components/NestedList/TableListItem.test.tsx
@@ -3,8 +3,8 @@ import { render } from '@testing-library/react';
 import UiLanguageContext from 'contexts/uiLanguageContext';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
-import { IDatabaseGroupHeader } from 'api/services/table';
 import { TableListItem } from './TableListItem';
+import { IDatabaseGroupHeader } from 'types/tableListItems';
 
 jest.mock('react-i18next', () => ({
     ...jest.requireActual('react-i18next'),

--- a/PxGraf.Frontend/src/components/NestedList/TableListItem.tsx
+++ b/PxGraf.Frontend/src/components/NestedList/TableListItem.tsx
@@ -9,10 +9,10 @@ import ExpandMore from '@mui/icons-material/ExpandMore';
 import ListViewIcon from '@mui/icons-material/ListAltOutlined';
 
 import { urls } from 'Router';
-import { IDatabaseGroupHeader } from 'api/services/table';
 import NestedList from './NestedList';
 import { UiLanguageContext } from 'contexts/uiLanguageContext';
-import { parseLanguageString } from '../../utils/ApiHelpers';
+import { parseLanguageString } from 'utils/ApiHelpers';
+import { IDatabaseGroupHeader } from 'types/tableListItems';
 
 interface ITableListItemProps {
     currentPath: string[];

--- a/PxGraf.Frontend/src/components/NestedList/__snapshots__/NestedList.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/NestedList/__snapshots__/NestedList.test.tsx.snap
@@ -138,11 +138,11 @@ exports[`Rendering test renders correctly 1`] = `
   />
   <li
     class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-jlHfjz cjyBDt css-1p823my-MuiListItem-root"
-    id="foo-bar-baz-asd2"
+    id="foo-bar-baz-asd2.px"
   >
     <a
       class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1skfnms-MuiButtonBase-root-MuiListItemButton-root"
-      href="/editor/foo/bar/baz/asd2/"
+      href="/editor/foo/bar/baz/asd2.px/"
       tabindex="0"
     >
       <div

--- a/PxGraf.Frontend/src/components/TableInfo/TableInfo.test.tsx
+++ b/PxGraf.Frontend/src/components/TableInfo/TableInfo.test.tsx
@@ -4,11 +4,11 @@ import { TableInfo } from './TableInfo';
 import '@testing-library/jest-dom';
 import UiLanguageContext from 'contexts/uiLanguageContext';
 import { MemoryRouter } from 'react-router-dom';
-import { IDatabaseTable } from '../../api/services/table';
+import { IDatabaseTable } from 'types/tableListItems';
 
 const mockPath = 'asd123';
 const mockItem: IDatabaseTable = {
-    code: 'id',
+    fileName: 'id',
     lastUpdated: '2021-10-13T14:53:06',
     name: { 'fi': 'text-fi', 'en': 'text-en', 'sv': 'text-sv'},
     languages: ['fi', 'en', 'sv'],
@@ -46,7 +46,7 @@ jest.mock('react-i18next', () => ({
 
 jest.mock('api/services/table', () => ({
     ...jest.requireActual('api/services/table'),
-    useTableQuery: (currentPath: string, language: string) => {
+    useTableQuery: () => {
         return mockTableQueryResult;
     },
 }));

--- a/PxGraf.Frontend/src/components/TableInfo/TableInfo.tsx
+++ b/PxGraf.Frontend/src/components/TableInfo/TableInfo.tsx
@@ -5,22 +5,17 @@ import React from 'react';
 import { urls } from 'Router';
 import { spacing } from 'utils/componentHelpers';
 import UiLanguageContext from 'contexts/uiLanguageContext';
-import { MultiLanguageString } from "../../types/multiLanguageString";
+import { IDatabaseTable } from 'types/tableListItems';
 
 interface ITableInfoProps {
     path: string;
-    item: {
-        code?: string;
-        lastUpdated?: string;
-        name?: MultiLanguageString;
-        languages?: string[];
-    };
+    item: IDatabaseTable;
 }
 
 export const TableInfo: React.FC<ITableInfoProps> = ({ path, item }) => {
     const { t } = useTranslation();
     const { language } = React.useContext(UiLanguageContext);
-    const currentPath = [path, item.code];
+    const currentPath = [path, item.fileName];
     const displayLanguage = item.languages.includes(language) ? language : item.languages[0];
 
     return (

--- a/PxGraf.Frontend/src/types/tableListItems.ts
+++ b/PxGraf.Frontend/src/types/tableListItems.ts
@@ -1,0 +1,44 @@
+/* istanbul ignore file */
+
+import { MultiLanguageString } from "./multiLanguageString";
+
+/**
+ * Interface for a section in the hierarchy of the table list.
+ * @property {IDatabaseGroupHeader[]} headers - The headers in the section.
+ * @property {IDatabaseTable[]} files - The tables in the section.
+ */
+export interface IDatabaseGroupContents {
+    headers: IDatabaseGroupHeader[];
+    files: IDatabaseTable[];
+}
+
+/**
+ * Interface for items shown on the table listing that can be sorted by the translated name.
+ * @property {MultiLanguageString} name - Localized names in all available languages.
+ * @property {string[]} languages - Available languages of the item. 
+ */
+export interface ISortableTableListItem {
+    name: MultiLanguageString;
+    languages: string[];
+}
+
+/***
+ * Interface for a table group header
+ * @property {string} code - The code of the table group.
+ * @property {MultiLanguageString} name - The name of the table group as a multi-language string.
+ */
+export interface IDatabaseGroupHeader extends ISortableTableListItem {
+    code: string;
+}
+
+/***
+ * Interface for a px table
+ * @property {fileName} fileName - Name of the px table file.
+ * @property {string} lastUpdated - The last updated date of the table.
+ * @property {boolean} error - Flag to indicate if there's an error with the table.
+ */
+export interface IDatabaseTable extends ISortableTableListItem {
+    fileName: string;
+    lastUpdated: string | null;
+    error?: boolean;
+}

--- a/PxGraf.Frontend/src/utils/sortingHelpers.test.ts
+++ b/PxGraf.Frontend/src/utils/sortingHelpers.test.ts
@@ -1,6 +1,6 @@
-import { IDatabaseTable } from '../api/services/table';
-import { sortDatabaseGroups, sortedDimensions } from './sortingHelpers';
-import { EMetaPropertyType, IDimension, EDimensionType } from "types/cubeMeta";
+import { EMetaPropertyType, IDimension, EDimensionType } from 'types/cubeMeta';
+import { sortDatabaseItems, sortedDimensions } from './sortingHelpers';
+import { IDatabaseTable } from 'types/tableListItems';
 
 const mockDimensions: IDimension[] =
 [
@@ -274,19 +274,19 @@ const mockDimensions: IDimension[] =
 
 const mockTableData: IDatabaseTable[] = [
     {
-        code: '0',
+        fileName: '0.px',
         lastUpdated: '2024-6-10',
         name: { en: 'Foo-en', fi: 'Foo-fi' },
         languages: ['en', 'fi'],
     },
     {
-        code: '1',
+        fileName: '1.px',
         lastUpdated: '2021-6-10',
         name: { en: 'Bar-en', fi: 'Bar-fi' },
         languages: ['en', 'fi'],
     },
     {
-        code: '2',
+        fileName: '2.px',
         lastUpdated: '2021-6-10',
         name: { fi: 'Baz-fi' },
         languages: ['fi'],
@@ -308,9 +308,9 @@ describe('Assertion tests', () => {
     });
 
     it('sorts table data by primary or first available language', () => {
-        const sortedData = sortDatabaseGroups(mockTableData, mockPrimaryLanguage);
-        const expected = ["1", "2", "0"];
-        const result = sortedData.map((item) => item.code);
+        const sortedData = sortDatabaseItems(mockTableData, mockPrimaryLanguage);
+        const expected = ["1.px", "2.px", "0.px"];
+        const result = sortedData.map((item) => item.fileName);
         expect(result).toEqual(expected);
     });
 });

--- a/PxGraf.Frontend/src/utils/sortingHelpers.ts
+++ b/PxGraf.Frontend/src/utils/sortingHelpers.ts
@@ -1,29 +1,16 @@
-import { IDatabaseGroupHeader, IDatabaseTable } from '../api/services/table';
-import { IDimension, IDimensionValue, EDimensionType } from "types/cubeMeta";
+import { IDimension, IDimensionValue, EDimensionType } from 'types/cubeMeta';
 import { getAdditionalPropertyValue } from './metadataUtils';
 import { eliminationKey } from './keywordConstants';
+import { ISortableTableListItem } from 'types/tableListItems';
 
 /**
- * Function for sorting databases based on the primary language.
- * @param {IDatabaseGroupHeader[]} data Databases or group headers to be sorted.
- * @param {string} primaryLanguage Primary language for sorting.
- * @returns Sorted databases or sub group headers.
+ * Sorts a group of database listing items based on their primary language name.
+ * Uses the first available language if the primary language is not available.
+ * @param data The group of database listing items to be sorted.
+ * @param primaryLanguage The primary language to be used for sorting.
+ * @returns A sorted list of database listing items.
  */
-export const sortDatabaseGroups = (data: IDatabaseGroupHeader[], primaryLanguage: string): IDatabaseGroupHeader[] => {
-    return sortDatabaseItems(data, primaryLanguage);
-};
-
-/**
- * Function for sorting tables based on the primary language.
- * @param {IDatabaseTable[]} data Tables to be sorted.
- * @param {string} primaryLanguage Primary language for sorting.
- * @returns Sorted tables.
- */
-export const sortDatabaseTables = (data: IDatabaseTable[], primaryLanguage: string): IDatabaseTable[] => {
-    return sortDatabaseItems(data, primaryLanguage);
-}
-
-const sortDatabaseItems = <T extends IDatabaseGroupHeader>(data: T[], primaryLanguage: string): T[] => {
+export const sortDatabaseItems = <T extends ISortableTableListItem>(data: T[], primaryLanguage: string): T[] => {
     return [...data].sort((a, b) => {
         const textA = a.name[primaryLanguage] || a.name[a.languages[0]];
         const textB = b.name[primaryLanguage] || b.name[a.languages[0]];

--- a/PxGraf.Frontend/src/views/TableListSelection/TableListSelection.test.tsx
+++ b/PxGraf.Frontend/src/views/TableListSelection/TableListSelection.test.tsx
@@ -64,7 +64,7 @@ const mockTableResult: ITableResult = {
         files: [
             {
                 name: { 'fi': 'foo3-fi', 'en': 'foo3-en', 'sv': 'foo3-sv' },
-                code: 'id2',
+                fileName: 'id2.px',
                 lastUpdated: '1.1.2000',
                 languages: ['fi', 'en', 'sv']
             }
@@ -74,7 +74,7 @@ const mockTableResult: ITableResult = {
 
 jest.mock('api/services/table', () => ({
     ...jest.requireActual('api/services/table'),
-    useTableQuery: (path: string, lang: string) => {
+    useTableQuery: () => {
         return mockTableResult;
     },
 }));

--- a/PxGraf.Frontend/src/views/TableListSelection/TableListSelection.tsx
+++ b/PxGraf.Frontend/src/views/TableListSelection/TableListSelection.tsx
@@ -1,13 +1,14 @@
-import { useParams } from "react-router-dom";
+import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { List, ListItem, Divider, Container, Skeleton, Alert } from '@mui/material';
 import React from 'react';
 import { UiLanguageContext } from 'contexts/uiLanguageContext';
 import { DirectoryInfo } from 'components/DirectoryInfo/DirectoryInfo';
-import TableInfo from "components/TableInfo/TableInfo";
-import styled from "styled-components";
-import { IDatabaseGroupHeader, IDatabaseTable, useTableQuery } from "api/services/table";
-import { sortDatabaseGroups, sortDatabaseTables } from 'utils/sortingHelpers';
+import TableInfo from 'components/TableInfo/TableInfo';
+import styled from 'styled-components';
+import { useTableQuery } from 'api/services/table';
+import { IDatabaseGroupHeader, IDatabaseTable } from 'types/tableListItems';
+import { sortDatabaseItems } from 'utils/sortingHelpers';
 
 const TableQueryAlert = styled(Alert)`
   width: 100%;
@@ -40,13 +41,13 @@ export const TableListSelection: React.FC = () => {
     const sortedGroups: IDatabaseGroupHeader[] = React.useMemo(() => {
         if (!data?.headers) return null;
 
-        return sortDatabaseGroups(data.headers, language);
+        return sortDatabaseItems(data.headers, language);
     }, [data, language]);
 
     const sortedTables: IDatabaseTable[] = React.useMemo(() => {
         if (!data?.files) return null;
 
-        return sortDatabaseTables(data.files, language);
+        return sortDatabaseItems(data.files, language);
     }, [data, language])
 
     let content: React.ReactNode;
@@ -84,7 +85,7 @@ export const TableListSelection: React.FC = () => {
                     <DirectoryInfo path={params["*"]} item={item} key={`${item.code}-directory-info`} />
                 ))}
                 {sortedTables.map((item) => (
-                    <TableInfo path={params["*"]} item={item} key={`${item.code}-table-info`} />
+                    <TableInfo path={params["*"]} item={item} key={`${item.fileName}-table-info`} />
                 ))}
             </>
         );

--- a/PxGraf.Frontend/src/views/TableListSelection/__snapshots__/TableListSelection.test.tsx.snap
+++ b/PxGraf.Frontend/src/views/TableListSelection/__snapshots__/TableListSelection.test.tsx.snap
@@ -17,15 +17,11 @@ exports[`Rendering test renders correctly 1`] = `
         <div
           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
         >
-          <span
-            class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-x61gb3-MuiTypography-root"
           >
-            <p
-              class="MuiTypography-root MuiTypography-body1 css-x61gb3-MuiTypography-root"
-            >
-              foo1-fi
-            </p>
-          </span>
+            foo1-fi
+          </p>
         </div>
         <span
           class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
@@ -43,15 +39,11 @@ exports[`Rendering test renders correctly 1`] = `
         <div
           class="MuiListItemText-root css-tlelie-MuiListItemText-root"
         >
-          <span
-            class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-x61gb3-MuiTypography-root"
           >
-            <p
-              class="MuiTypography-root MuiTypography-body1 css-x61gb3-MuiTypography-root"
-            >
-              foo2-fi
-            </p>
-          </span>
+            foo2-fi
+          </p>
         </div>
         <span
           class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
@@ -62,7 +54,7 @@ exports[`Rendering test renders correctly 1`] = `
       />
       <a
         class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-        href="/editor/foo/bar/id2/"
+        href="/editor/foo/bar/id2.px/"
         id="mainContent"
         tabindex="0"
       >

--- a/PxGraf.Frontend/src/views/TableTreeSelection/TableTreeSelection.test.tsx
+++ b/PxGraf.Frontend/src/views/TableTreeSelection/TableTreeSelection.test.tsx
@@ -52,13 +52,13 @@ const mockTableResult: ITableResult = {
         files: [
             {
                 name: { 'fi': 'foo1', 'en': 'foo1', 'sv': 'foo1' },
-                code: 'id1',
+                fileName: 'id1.px',
                 lastUpdated: '1.1.2000',
                 languages: ['fi', 'en', 'sv']
             },
             {
                 name: { 'fi': 'foo2', 'en': 'foo2' },
-                code: 'id2',
+                fileName: 'id2.px',
                 lastUpdated: '1.1.2000',
                 languages: ['fi', 'en']
             }

--- a/PxGraf.Frontend/src/views/TableTreeSelection/__snapshots__/TableTreeSelection.test.tsx.snap
+++ b/PxGraf.Frontend/src/views/TableTreeSelection/__snapshots__/TableTreeSelection.test.tsx.snap
@@ -40,11 +40,11 @@ exports[`Rendering test renders correctly 1`] = `
       </div>
       <li
         class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-khdDuB jYEFrN css-1p823my-MuiListItem-root"
-        id="id1"
+        id="id1.px"
       >
         <a
           class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-un12p1-MuiButtonBase-root-MuiListItemButton-root"
-          href="/editor/id1/"
+          href="/editor/id1.px/"
           tabindex="0"
         >
           <div
@@ -86,11 +86,11 @@ exports[`Rendering test renders correctly 1`] = `
       />
       <li
         class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-khdDuB jYEFrN css-1p823my-MuiListItem-root"
-        id="id2"
+        id="id2.px"
       >
         <a
           class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-un12p1-MuiButtonBase-root-MuiListItemButton-root"
-          href="/editor/id2/"
+          href="/editor/id2.px/"
           tabindex="0"
         >
           <div

--- a/PxGraf/Controllers/CreationController.cs
+++ b/PxGraf/Controllers/CreationController.cs
@@ -24,7 +24,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System;
-using System.Text.Json;
 
 namespace PxGraf.Controllers
 {

--- a/PxGraf/Datasource/FileDatasource/CachedFileDatasource.cs
+++ b/PxGraf/Datasource/FileDatasource/CachedFileDatasource.cs
@@ -14,7 +14,6 @@ using PxGraf.Settings;
 using PxGraf.Utility;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -54,19 +53,17 @@ namespace PxGraf.Datasource.FileDatasource
             {
                 IReadOnlyMatrixMetadata meta = await GetMatrixMetadataCachedAsync(reference);
                 DateTime? lastUpdated = meta.GetLastUpdated();
-                string tableId = meta.AdditionalProperties.TryGetValue(PxSyntaxConstants.TABLEID_KEY, out MetaProperty? tableIdProperty) &&
-                    tableIdProperty is StringProperty stringIdProp ? stringIdProp.Value : Path.GetFileNameWithoutExtension(reference.Name);
 
                 List<string> languages = [.. meta.AvailableLanguages];
-                MultilanguageString name = new(languages.ToDictionary(lang => lang, lang => tableId));
+                MultilanguageString name = new(languages.ToDictionary(lang => lang, lang => reference.Name));
                 if (meta.AdditionalProperties.TryGetValue(PxSyntaxConstants.DESCRIPTION_KEY, out MetaProperty? descriptionProperty))
                 {
                     if (descriptionProperty is StringProperty sProp) name = new(languages[0], sProp.Value);
                     else if (descriptionProperty is MultilanguageStringProperty mlsProp) name = mlsProp.Value;
                 }
 
-                if (lastUpdated is not null) return new(tableId, name, (DateTime)lastUpdated, languages);
-                else return DatabaseTable.FromError(tableId, name, languages);
+                if (lastUpdated is not null) return new(reference.Name, name, (DateTime)lastUpdated, languages);
+                else return DatabaseTable.FromError(reference.Name, name, languages);
             }
             catch (Exception e)
             {

--- a/PxGraf/Datasource/FileDatasource/LocalFilesystemDatabase.cs
+++ b/PxGraf/Datasource/FileDatasource/LocalFilesystemDatabase.cs
@@ -111,8 +111,6 @@ namespace PxGraf.Datasource.FileDatasource
             )
         {
             string path = PathUtils.BuildAndSanitizePath(config.DatabaseRootPath, tableReference);
-            if (!path.EndsWith(PxSyntaxConstants.PX_FILE_EXTENSION))
-                path += PxSyntaxConstants.PX_FILE_EXTENSION;
             DataIndexer indexer = new(completeTableMap, meta);
             Matrix<DecimalDataValue> output = new(meta, new DecimalDataValue[indexer.DataLength]);
             using Stream fileStream = File.OpenRead(path);
@@ -125,9 +123,6 @@ namespace PxGraf.Datasource.FileDatasource
         /// <inheritdoc/> 
         public async Task<IReadOnlyMatrixMetadata> GetMatrixMetadataAsync(PxTableReference tableReference)
         {
-            if (!tableReference.Name.EndsWith(PxSyntaxConstants.PX_FILE_EXTENSION))
-                tableReference.Name += PxSyntaxConstants.PX_FILE_EXTENSION;
-
             string path = PathUtils.BuildAndSanitizePath(config.DatabaseRootPath, tableReference);
             using Stream readStream = File.OpenRead(path);
             PxFileMetadataReader metadataReader = new();

--- a/PxGraf/Models/Responses/DatabaseItems/DatabaseTable.cs
+++ b/PxGraf/Models/Responses/DatabaseItems/DatabaseTable.cs
@@ -14,7 +14,7 @@ namespace PxGraf.Models.Responses.DatabaseItems
         /// <summary>
         /// Code of the database table.
         /// </summary>
-        public string Code { get; private set; }
+        public string FileName { get; private set; }
         /// <summary>
         /// Multilanguage name of the database table.
         /// </summary>
@@ -34,17 +34,17 @@ namespace PxGraf.Models.Responses.DatabaseItems
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? Error { get; private set; } = null;
 
-        public DatabaseTable(string code, MultilanguageString name, DateTime lastUpdated, List<string> languages)
+        public DatabaseTable(string fileName, MultilanguageString name, DateTime lastUpdated, List<string> languages)
         {
-            Code = code;
+            FileName = fileName;
             Name = name;
             LastUpdated = lastUpdated;
             Languages = languages;
         }
 
-        private DatabaseTable(string code, MultilanguageString name, List<string> languages)
+        private DatabaseTable(string fileName, MultilanguageString name, List<string> languages)
         {
-            Code = code;
+            FileName = fileName;
             Name = name;
             Languages = languages;
             Error = true;

--- a/PxGraf/PxGraf.csproj
+++ b/PxGraf/PxGraf.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>PxGraf</AssemblyName>
     <UserSecretsId>5fefcbdc-e04e-4475-9927-aab412b027ff</UserSecretsId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>4.0.5</VersionPrefix>
+    <VersionPrefix>4.0.6</VersionPrefix>
 	<SpaRoot>..\PxGraf.Frontend</SpaRoot>
 	<Configurations>Debug;Release;Test</Configurations>
   </PropertyGroup>

--- a/UnitTests/ControllerTests/CreationControllerTests/GetDataBaseListingTests.cs
+++ b/UnitTests/ControllerTests/CreationControllerTests/GetDataBaseListingTests.cs
@@ -76,7 +76,7 @@ namespace UnitTests.ControllerTests.CreationControllerTests
             // Assert
             Assert.That(result, Is.Not.Null);
             Assert.That(result.Files, Is.EqualTo(expectedTables));
-            Assert.That(expectedTables[0].Code, Is.EqualTo(result.Files[0].Code));
+            Assert.That(expectedTables[0].FileName, Is.EqualTo(result.Files[0].FileName));
         }
     }
 }

--- a/UnitTests/DatasourceTests/CachedApiDataSourceTests.cs
+++ b/UnitTests/DatasourceTests/CachedApiDataSourceTests.cs
@@ -99,8 +99,8 @@ namespace UnitTests.DatasourceTests
             // Arrange
             List<DatabaseTable> mockTables =
                 [
-                    new("table1-id", new MultilanguageString(_table1Name), _lastUpdated, _languages),
-                    new("table2-id", new MultilanguageString(_table2Name), _lastUpdated, _languages),
+                    new("table1.px", new MultilanguageString(_table1Name), _lastUpdated, _languages),
+                    new("table2.px", new MultilanguageString(_table2Name), _lastUpdated, _languages),
                 ];
 
             Mock<IApiDatasource> mockSource = new();
@@ -116,14 +116,14 @@ namespace UnitTests.DatasourceTests
             Assert.That(contents.Headers.Count, Is.EqualTo(0));
 
             DatabaseTable file0 = contents.Files[0];
-            Assert.That(file0.Code, Is.EqualTo("table1-id"));
+            Assert.That(file0.FileName, Is.EqualTo("table1.px"));
             Assert.That(file0.Name["fi"], Is.EqualTo("Table1"));
             Assert.That(file0.Name["en"], Is.EqualTo("Table1.en"));
             Assert.That(file0.Name["sv"], Is.EqualTo("Table1.sv"));
             Assert.That(file0.LastUpdated, Is.EqualTo(_lastUpdated));
 
             DatabaseTable file1 = contents.Files[1];
-            Assert.That(file1.Code, Is.EqualTo("table2-id"));
+            Assert.That(file1.FileName, Is.EqualTo("table2.px"));
             Assert.That(file1.Name["fi"], Is.EqualTo("Table2"));
             Assert.That(file1.Name["en"], Is.EqualTo("Table2.en"));
             Assert.That(file1.Name["sv"], Is.EqualTo("Table2.sv"));
@@ -142,8 +142,8 @@ namespace UnitTests.DatasourceTests
 
             List<DatabaseTable> mockTables =
                 [
-                    new("table1-id", new MultilanguageString(_table1Name), _lastUpdated, _languages),
-                    new("table2-id", new MultilanguageString(_table2Name), _lastUpdated, _languages),
+                    new("table1.px", new MultilanguageString(_table1Name), _lastUpdated, _languages),
+                    new("table2.px", new MultilanguageString(_table2Name), _lastUpdated, _languages),
                 ];
 
             Mock<IApiDatasource> mockSource = new();

--- a/UnitTests/DatasourceTests/CachedFileDatasourceTests.cs
+++ b/UnitTests/DatasourceTests/CachedFileDatasourceTests.cs
@@ -117,7 +117,7 @@ namespace UnitTests.DatasourceTests
 
             MatrixMetadata brokenMeta = TestDataCubeBuilder.BuildTestMeta(noContent, [.. _languages]);
 
-            StringProperty table1IDProperty = new("table1-id");
+            StringProperty table1IDProperty = new("table1.px");
             table1Meta.AdditionalProperties[PxSyntaxConstants.TABLEID_KEY] = table1IDProperty; // Adds TABLE_ID property for table1
             table1Meta.AdditionalProperties[PxSyntaxConstants.DESCRIPTION_KEY] = new MultilanguageStringProperty(new MultilanguageString(_table1Name));
             table2Meta.AdditionalProperties[PxSyntaxConstants.DESCRIPTION_KEY] = new MultilanguageStringProperty(new MultilanguageString(_table2Name));
@@ -137,21 +137,21 @@ namespace UnitTests.DatasourceTests
             Assert.That(contents.Files.Count, Is.EqualTo(3));
 
             DatabaseTable file0 = contents.Files[0];
-            Assert.That(file0.Code, Is.EqualTo("table1-id"));
+            Assert.That(file0.FileName, Is.EqualTo("table_1.px"));
             Assert.That(file0.Name["fi"], Is.EqualTo("Table1"));
             Assert.That(file0.Name["en"], Is.EqualTo("Table1.en"));
             Assert.That(file0.Name["sv"], Is.EqualTo("Table1.sv"));
             Assert.That(file0.LastUpdated, Is.EqualTo(_lastUpdated));
 
             DatabaseTable file1 = contents.Files[1];
-            Assert.That(file1.Code, Is.EqualTo("table_2"));
+            Assert.That(file1.FileName, Is.EqualTo("table_2.px"));
             Assert.That(file1.Name["fi"], Is.EqualTo("Table2"));
             Assert.That(file1.Name["en"], Is.EqualTo("Table2.en"));
             Assert.That(file1.Name["sv"], Is.EqualTo("Table2.sv"));
             Assert.That(file1.LastUpdated, Is.EqualTo(_lastUpdated));
 
             DatabaseTable file2 = contents.Files[2];
-            Assert.That(file2.Code, Is.EqualTo("table_3"));
+            Assert.That(file2.FileName, Is.EqualTo("table_3.px"));
             Assert.That(file2.LastUpdated, Is.Null);
             Assert.That(file2.Error, Is.True);
         }


### PR DESCRIPTION
Fixed an issue where the tables were identified based on the tableid. Matching this to the actual file paths caused issues for external systems. Reverted the change and now tables are again identified by the file name.