### PR TITLE
Fix: input fields lose focus on edit

### DIFF
--- a/PxGraf.Frontend/package.json
+++ b/PxGraf.Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxgraf",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.4",

--- a/PxGraf.Frontend/src/components/MetaEditor/EditorField.test.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/EditorField.test.tsx
@@ -37,6 +37,10 @@ describe('Rendering test', () => {
         const { asFragment } = render(<EditorField maxLength={11} defaultValue={'foobarbaz1'} editValue={'foobarbaz1'} label={mockLabel} onChange={mockFunction} />);
         expect(asFragment()).toMatchSnapshot();
     });
+    it('renders correctly if the value hsa not been edited', () => {
+        const { asFragment } = render(<EditorField defaultValue={mockDefaultValue} editValue={null} label={mockLabel} onChange={mockFunction} />);
+        expect(asFragment()).toMatchSnapshot();
+    });
 });
 
 describe('Assertion tests', () => {

--- a/PxGraf.Frontend/src/components/MetaEditor/Editorfield.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/Editorfield.tsx
@@ -13,25 +13,15 @@ interface IEditorFieldProps {
     maxLength?: number;
 }
 
-const StyledEditedOutlinedInput = styled(({ ...other }) => <OutlinedInput {...other} />)({
-    backgroundColor: 'var(--editorfield-background-edited)',
+const StyledOutlinedInput = styled(OutlinedInput)<{ isEdited: boolean }>(({ isEdited }) => ({
+    backgroundColor: isEdited ? 'var(--editorfield-background-edited)' : 'var(--editorfield-background)',
     '& .MuiOutlinedInput-notchedOutline': {
-        borderColor: 'var(--editorfield-outline-edited)'
+        borderColor: isEdited ? 'var(--editorfield-outline-edited)' : 'var(--editorfield-outline)',
     },
     '& input': {
-        fontWeight: 'bold'
+        fontWeight: isEdited ? 'bold' : 'normal',
     }
-});
-
-const StyledOutlinedInput = styled(({ ...other }) => <OutlinedInput {...other} />)({
-    backgroundColor: 'var(--editorfield-background)',
-    '& .MuiOutlinedInput-notchedOutline': {
-        borderColor: 'var(--editorfield-outline)',
-    },
-    '& input': {
-        fontWeight: 'normal',
-    }
-});
+}));
 
 export const EditorField: React.FC<IEditorFieldProps> = ({ label, defaultValue, editValue, onChange, maxLength, style = {} }) => {
     const { t } = useTranslation();
@@ -45,7 +35,7 @@ export const EditorField: React.FC<IEditorFieldProps> = ({ label, defaultValue, 
     return (
         <FormControl variant="outlined" style={style}>
             <InputLabel htmlFor={inputId}>{isEdited ? <b>{label + '*'}</b> : label}</InputLabel>
-            { isEdited ? <StyledEditedOutlinedInput
+            <StyledOutlinedInput
                 id={inputId}
                 type='text'
                 value={value.substring(0, maxLength || value.length)}
@@ -54,23 +44,15 @@ export const EditorField: React.FC<IEditorFieldProps> = ({ label, defaultValue, 
                     onChange(parsedValue);
                 }}
                 endAdornment={
-                    <InputAdornment position="end">
-                        <RevertButton onClick={onChange} />
-                    </InputAdornment>
+                    isEdited && (
+                        <InputAdornment position="end">
+                            <RevertButton onClick={onChange} />
+                        </InputAdornment>
+                    )
                 }
                 label={label}
+                isEdited={isEdited}
             />
-            : <StyledOutlinedInput
-                id={inputId}
-                type='text'
-                value={value.substring(0, maxLength || value.length)}
-                onChange={evt => {
-                    const parsedValue = evt.target.value.substring(0, maxLength || evt.target.value.length);
-                    onChange(parsedValue);
-                }}
-                label={label}
-            />
-            }
             <div aria-live='polite'>
             {
                 showAlert &&

--- a/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/BasicDimensionEditor.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/BasicDimensionEditor.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiStack-root sc-egkSDF jGJtNr css-1sazv7p-MuiStack-root"
+    class="MuiStack-root sc-gtLWhw QCIdg css-1sazv7p-MuiStack-root"
   >
     <div
       class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
@@ -18,7 +18,7 @@ exports[`Rendering test renders correctly 1`] = `
         </b>
       </label>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb dwkEzj css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb bwJxkv css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <input
           aria-invalid="false"

--- a/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/ContentDimensionEditor.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/ContentDimensionEditor.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Rendering test renders correctly 1`] = `
         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-172kgz0-MuiPaper-root"
       >
         <div
-          class="MuiStack-root sc-egkSDF emnLII css-1sazv7p-MuiStack-root"
+          class="MuiStack-root sc-gtLWhw cmNKGv css-1sazv7p-MuiStack-root"
         >
           <div
             class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
@@ -27,7 +27,7 @@ exports[`Rendering test renders correctly 1`] = `
               </b>
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb dwkEzj css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb bwJxkv css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
@@ -95,7 +95,7 @@ exports[`Rendering test renders correctly 1`] = `
               editMetadata.unit
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw kNXXit css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-blHHSb bgrSMJ css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
@@ -132,7 +132,7 @@ exports[`Rendering test renders correctly 1`] = `
               editMetadata.source
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw kNXXit css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-blHHSb bgrSMJ css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"

--- a/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/ContentDimensionValueEditor.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/ContentDimensionValueEditor.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Rendering test renders correctly 1`] = `
     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-172kgz0-MuiPaper-root"
   >
     <div
-      class="MuiStack-root sc-egkSDF emnLII css-1sazv7p-MuiStack-root"
+      class="MuiStack-root sc-gtLWhw cmNKGv css-1sazv7p-MuiStack-root"
     >
       <div
         class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
@@ -19,7 +19,7 @@ exports[`Rendering test renders correctly 1`] = `
           editMetadata.valueName: asd
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw kNXXit css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-blHHSb bgrSMJ css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
@@ -56,7 +56,7 @@ exports[`Rendering test renders correctly 1`] = `
           editMetadata.unit
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw kNXXit css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-blHHSb bgrSMJ css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
@@ -93,7 +93,7 @@ exports[`Rendering test renders correctly 1`] = `
           editMetadata.source
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw kNXXit css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-blHHSb bgrSMJ css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"

--- a/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/DimensionEditor.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/DimensionEditor.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Rendering test renders correctly 1`] = `
         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-172kgz0-MuiPaper-root"
       >
         <div
-          class="MuiStack-root sc-egkSDF emnLII css-1sazv7p-MuiStack-root"
+          class="MuiStack-root sc-gtLWhw cmNKGv css-1sazv7p-MuiStack-root"
         >
           <div
             class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
@@ -27,7 +27,7 @@ exports[`Rendering test renders correctly 1`] = `
               </b>
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb dwkEzj css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb bwJxkv css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
@@ -95,7 +95,7 @@ exports[`Rendering test renders correctly 1`] = `
               editMetadata.unit
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw kNXXit css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-blHHSb bgrSMJ css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
@@ -132,7 +132,7 @@ exports[`Rendering test renders correctly 1`] = `
               editMetadata.source
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw kNXXit css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-blHHSb bgrSMJ css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"

--- a/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/EditorField.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/EditorField.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Rendering test renders correctly 1`] = `
       </b>
     </label>
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb dwkEzj css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb bwJxkv css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
     >
       <input
         aria-invalid="false"
@@ -90,7 +90,7 @@ exports[`Rendering test renders correctly if limit close 1`] = `
       </b>
     </label>
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb dwkEzj css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb bwJxkv css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
     >
       <input
         aria-invalid="false"
@@ -191,7 +191,7 @@ exports[`Rendering test renders correctly if limit reached 1`] = `
       </b>
     </label>
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb dwkEzj css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb bwJxkv css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
     >
       <input
         aria-invalid="false"
@@ -292,7 +292,7 @@ exports[`Rendering test renders correctly if limit specified but values are shor
       </b>
     </label>
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb dwkEzj css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb bwJxkv css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
     >
       <input
         aria-invalid="false"
@@ -332,6 +332,48 @@ exports[`Rendering test renders correctly if limit specified but values are shor
           </button>
         </span>
       </div>
+      <fieldset
+        aria-hidden="true"
+        class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+      >
+        <legend
+          class="css-14lo706"
+        >
+          <span>
+            label
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+    <div
+      aria-live="polite"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Rendering test renders correctly if the value hsa not been edited 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
+  >
+    <label
+      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+      data-shrink="true"
+      for=":r8:"
+    >
+      label
+    </label>
+    <div
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-blHHSb bgrSMJ css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+    >
+      <input
+        aria-invalid="false"
+        class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+        id=":r8:"
+        type="text"
+        value="defaultValue"
+      />
       <fieldset
         aria-hidden="true"
         class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"

--- a/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/HeaderEditor.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/HeaderEditor.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-ghWlax fonjz"
+    class="sc-ivxoEo lglpeY"
   >
     <div
-      class="sc-ivxoEo fWiUCd"
+      class="sc-dntaoT ecSOzH"
     >
       <button
         aria-label="tooltip.open: editMetadata.header"
-        class="sc-egkSDF exohjD"
+        class="sc-gtLWhw dwjhoM"
       >
         <svg
           aria-hidden="true"
@@ -37,7 +37,7 @@ exports[`Rendering test renders correctly 1`] = `
           </b>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb dwkEzj css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-blHHSb bwJxkv css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
@@ -102,7 +102,7 @@ exports[`Rendering test renders correctly 1`] = `
 exports[`Rendering test renders correctly when loading 1`] = `
 <DocumentFragment>
   <div
-    class="sc-ghWlax fonjz"
+    class="sc-ivxoEo lglpeY"
   >
     <span
       class="MuiSkeleton-root MuiSkeleton-rectangular MuiSkeleton-pulse css-153n0d3-MuiSkeleton-root"
@@ -115,7 +115,7 @@ exports[`Rendering test renders correctly when loading 1`] = `
 exports[`Rendering test renders correctly when receiving error 1`] = `
 <DocumentFragment>
   <div
-    class="sc-ghWlax fonjz"
+    class="sc-ivxoEo lglpeY"
   >
     <div
       class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorError MuiAlert-standardError MuiAlert-standard css-x7o5da-MuiPaper-root-MuiAlert-root"

--- a/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/MetaEditor.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/MetaEditor.test.tsx.snap
@@ -3,17 +3,17 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-dpBQxM cAGkDL MuiBox-root css-0"
+    class="sc-keTIit iEZRuv MuiBox-root css-0"
   >
     <div
-      class="sc-keTIit kBNIsw"
+      class="sc-dstKZu beBTtl"
     >
       <div
-        class="sc-dstKZu cHueHc"
+        class="sc-khLCKb gYRtPq"
       >
         <button
           aria-label="tooltip.open: editMetadata.header"
-          class="sc-kLhKbu gOGwLg"
+          class="sc-ghWlax bEVwpO"
         >
           <svg
             aria-hidden="true"
@@ -41,7 +41,7 @@ exports[`Rendering test renders correctly 1`] = `
             </b>
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-gtLWhw hRlndP css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-gtLWhw flyNmf css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
@@ -101,14 +101,14 @@ exports[`Rendering test renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-ovuCP cvwpWF"
+      class="sc-cEzcPc iUUCmm"
     >
       <div
-        class="sc-cEzcPc cJIRkL"
+        class="sc-jtQUzJ drtSIt"
       >
         <button
           aria-label="tooltip.open: editMetadata.editorTitle"
-          class="sc-kLhKbu gOGwLg"
+          class="sc-ghWlax bEVwpO"
         >
           <svg
             aria-hidden="true"
@@ -123,7 +123,7 @@ exports[`Rendering test renders correctly 1`] = `
           </svg>
         </button>
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-jwIPbr fBGMMc css-1086bdv-MuiPaper-root-MuiAccordion-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-dpBQxM dvJsbi css-1086bdv-MuiPaper-root-MuiAccordion-root"
         >
           <div
             aria-controls="panel1a-content"
@@ -176,10 +176,10 @@ exports[`Rendering test renders correctly 1`] = `
                   role="region"
                 >
                   <div
-                    class="MuiAccordionDetails-root sc-eOzmre gZxVwT css-15v22id-MuiAccordionDetails-root"
+                    class="MuiAccordionDetails-root sc-ovuCP kmuGeq css-15v22id-MuiAccordionDetails-root"
                   >
                     <div
-                      class="sc-cHqXqK dDSxAr MuiBox-root css-1mc6bnb"
+                      class="sc-jwIPbr itDDef MuiBox-root css-1mc6bnb"
                     >
                       <div
                         class="MuiTabs-root css-1ujnqem-MuiTabs-root"
@@ -229,7 +229,7 @@ exports[`Rendering test renders correctly 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-jtQUzJ gSfZU MuiBox-root css-0"
+                      class="sc-cHqXqK FSQTe MuiBox-root css-0"
                     >
                       <div
                         aria-labelledby="simple-tab-0"
@@ -249,7 +249,7 @@ exports[`Rendering test renders correctly 1`] = `
                                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-172kgz0-MuiPaper-root"
                               >
                                 <div
-                                  class="MuiStack-root sc-fAUdSK geoqZq css-1sazv7p-MuiStack-root"
+                                  class="MuiStack-root sc-egkSDF emnLII css-1sazv7p-MuiStack-root"
                                 >
                                   <div
                                     class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
@@ -262,7 +262,7 @@ exports[`Rendering test renders correctly 1`] = `
                                       editMetadata.valueName: fgfgfg
                                     </label>
                                     <div
-                                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-egkSDF cnFbIu css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw hXgXvF css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
                                     >
                                       <input
                                         aria-invalid="false"
@@ -299,7 +299,7 @@ exports[`Rendering test renders correctly 1`] = `
                                       editMetadata.unit
                                     </label>
                                     <div
-                                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-egkSDF cnFbIu css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw hXgXvF css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
                                     >
                                       <input
                                         aria-invalid="false"
@@ -336,7 +336,7 @@ exports[`Rendering test renders correctly 1`] = `
                                       editMetadata.source
                                     </label>
                                     <div
-                                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-egkSDF cnFbIu css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw hXgXvF css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
                                     >
                                       <input
                                         aria-invalid="false"

--- a/PxGraf.Frontend/src/components/NestedList/__snapshots__/NestedList.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/NestedList/__snapshots__/NestedList.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`Rendering test renders correctly 1`] = `
     class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
   />
   <li
-    class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-hRgSog cwZhKz css-1p823my-MuiListItem-root"
+    class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-jlHfjz cjyBDt css-1p823my-MuiListItem-root"
     id="foo-bar-baz-asd2.px"
   >
     <a
@@ -191,7 +191,7 @@ exports[`Rendering test renders correctly when table query  1`] = `
     class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p823my-MuiListItem-root"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorError MuiAlert-standardError MuiAlert-standard sc-geoRQH dALrbK css-r1b7i3-MuiPaper-root-MuiAlert-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorError MuiAlert-standardError MuiAlert-standard sc-ikngxL jsjOzD css-r1b7i3-MuiPaper-root-MuiAlert-root"
       role="alert"
     >
       <div
@@ -231,11 +231,11 @@ exports[`Rendering test renders correctly while loading data 1`] = `
       class="MuiListItemIcon-root css-mbw9t7-MuiListItemIcon-root"
     >
       <span
-        class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse sc-gFtjaa iRfUJv css-wkdwxb-MuiSkeleton-root"
+        class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse sc-jwaPLR fEXghW css-wkdwxb-MuiSkeleton-root"
       />
     </div>
     <div
-      class="MuiListItemText-root sc-ikngxL dIDvwr css-tlelie-MuiListItemText-root"
+      class="MuiListItemText-root sc-gFtjaa bKoyQX css-tlelie-MuiListItemText-root"
     >
       <span
         class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-10hburv-MuiTypography-root"

--- a/PxGraf.Frontend/src/components/NestedList/__snapshots__/TableItem.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/NestedList/__snapshots__/TableItem.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <li
-    class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-ikngxL ca-dmKW css-1p823my-MuiListItem-root"
+    class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-gFtjaa hrmFyq css-1p823my-MuiListItem-root"
     id="foo-bar-baz"
   >
     <a

--- a/PxGraf.Frontend/src/views/Editor/__snapshots__/EditorMetaSection.test.tsx.snap
+++ b/PxGraf.Frontend/src/views/Editor/__snapshots__/EditorMetaSection.test.tsx.snap
@@ -3,22 +3,22 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-fwzISk brlPLd MuiBox-root css-0"
+    class="sc-hJRrWL hGieJy MuiBox-root css-0"
   >
     <div
-      class="sc-hbtGpV jgpYNU MuiBox-root css-1mc6bnb"
+      class="sc-fwzISk ORqjR MuiBox-root css-1mc6bnb"
     >
       <div
-        class="sc-diYFot lnYwNY"
+        class="sc-kZrBCu byHwEi"
       >
         <p
-          class="MuiTypography-root MuiTypography-body2 sc-bMTdWJ bAFfNv css-r40f8v-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body2 sc-hbtGpV iETdla css-r40f8v-MuiTypography-root"
         >
           editor.contentLanguage
         </p>
         <button
           aria-label="tooltip.open: editor.contentLanguage"
-          class="sc-kLhKbu gOGwLg"
+          class="sc-ghWlax bEVwpO"
         >
           <svg
             aria-hidden="true"
@@ -48,7 +48,7 @@ exports[`Rendering test renders correctly 1`] = `
               aria-controls="simple-tabpanel-fi"
               aria-label="editor.contentLanguage: lang.local.fi"
               aria-selected="true"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected sc-jhZTHU hYxLpM css-nujr79-MuiButtonBase-root-MuiTab-root"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected sc-bMTdWJ eGjIiX css-nujr79-MuiButtonBase-root-MuiTab-root"
               id="simple-tab-fi"
               role="tab"
               tabindex="0"
@@ -63,7 +63,7 @@ exports[`Rendering test renders correctly 1`] = `
               aria-controls="simple-tabpanel-sv"
               aria-label="editor.contentLanguage: lang.local.sv"
               aria-selected="false"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary sc-jhZTHU hYxLpM css-nujr79-MuiButtonBase-root-MuiTab-root"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary sc-bMTdWJ eGjIiX css-nujr79-MuiButtonBase-root-MuiTab-root"
               id="simple-tab-sv"
               role="tab"
               tabindex="-1"
@@ -78,7 +78,7 @@ exports[`Rendering test renders correctly 1`] = `
               aria-controls="simple-tabpanel-en"
               aria-label="editor.contentLanguage: lang.local.en"
               aria-selected="false"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary sc-jhZTHU hYxLpM css-nujr79-MuiButtonBase-root-MuiTab-root"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary sc-bMTdWJ eGjIiX css-nujr79-MuiButtonBase-root-MuiTab-root"
               id="simple-tab-en"
               role="tab"
               tabindex="-1"
@@ -98,7 +98,7 @@ exports[`Rendering test renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-epnzzT gppysx MuiBox-root css-0"
+      class="sc-jhZTHU fHxKQz MuiBox-root css-0"
     >
       <div
         aria-labelledby="simple-tab-fi"
@@ -109,17 +109,17 @@ exports[`Rendering test renders correctly 1`] = `
           class="sc-blHHSb dKmohW MuiBox-root css-0"
         >
           <div
-            class="sc-dpBQxM cAGkDL MuiBox-root css-0"
+            class="sc-keTIit iEZRuv MuiBox-root css-0"
           >
             <div
-              class="sc-keTIit kBNIsw"
+              class="sc-dstKZu beBTtl"
             >
               <div
-                class="sc-dstKZu cHueHc"
+                class="sc-khLCKb gYRtPq"
               >
                 <button
                   aria-label="tooltip.open: editMetadata.header"
-                  class="sc-kLhKbu gOGwLg"
+                  class="sc-ghWlax bEVwpO"
                 >
                   <svg
                     aria-hidden="true"
@@ -145,7 +145,7 @@ exports[`Rendering test renders correctly 1`] = `
                     editMetadata.header
                   </label>
                   <div
-                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-egkSDF cnFbIu css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw hXgXvF css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
                   >
                     <input
                       aria-invalid="false"
@@ -174,14 +174,14 @@ exports[`Rendering test renders correctly 1`] = `
               </div>
             </div>
             <div
-              class="sc-ovuCP cvwpWF"
+              class="sc-cEzcPc iUUCmm"
             >
               <div
-                class="sc-cEzcPc cJIRkL"
+                class="sc-jtQUzJ drtSIt"
               >
                 <button
                   aria-label="tooltip.open: editMetadata.editorTitle"
-                  class="sc-kLhKbu gOGwLg"
+                  class="sc-ghWlax bEVwpO"
                 >
                   <svg
                     aria-hidden="true"
@@ -196,7 +196,7 @@ exports[`Rendering test renders correctly 1`] = `
                   </svg>
                 </button>
                 <div
-                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters sc-jwIPbr fBGMMc css-1086bdv-MuiPaper-root-MuiAccordion-root"
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters sc-dpBQxM dvJsbi css-1086bdv-MuiPaper-root-MuiAccordion-root"
                 >
                   <div
                     aria-controls="panel1a-content"
@@ -249,10 +249,10 @@ exports[`Rendering test renders correctly 1`] = `
                           role="region"
                         >
                           <div
-                            class="MuiAccordionDetails-root sc-eOzmre gZxVwT css-15v22id-MuiAccordionDetails-root"
+                            class="MuiAccordionDetails-root sc-ovuCP kmuGeq css-15v22id-MuiAccordionDetails-root"
                           >
                             <div
-                              class="sc-cHqXqK dDSxAr MuiBox-root css-1mc6bnb"
+                              class="sc-jwIPbr itDDef MuiBox-root css-1mc6bnb"
                             >
                               <div
                                 class="MuiTabs-root css-1ujnqem-MuiTabs-root"
@@ -302,7 +302,7 @@ exports[`Rendering test renders correctly 1`] = `
                               </div>
                             </div>
                             <div
-                              class="sc-jtQUzJ gSfZU MuiBox-root css-0"
+                              class="sc-cHqXqK FSQTe MuiBox-root css-0"
                             >
                               <div
                                 aria-labelledby="simple-tab-0"
@@ -322,7 +322,7 @@ exports[`Rendering test renders correctly 1`] = `
                                         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-172kgz0-MuiPaper-root"
                                       >
                                         <div
-                                          class="MuiStack-root sc-fAUdSK geoqZq css-1sazv7p-MuiStack-root"
+                                          class="MuiStack-root sc-egkSDF emnLII css-1sazv7p-MuiStack-root"
                                         >
                                           <div
                                             class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
@@ -335,7 +335,7 @@ exports[`Rendering test renders correctly 1`] = `
                                               editMetadata.valueName: fgfgfg1
                                             </label>
                                             <div
-                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-egkSDF cnFbIu css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw hXgXvF css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
                                             >
                                               <input
                                                 aria-invalid="false"
@@ -372,7 +372,7 @@ exports[`Rendering test renders correctly 1`] = `
                                               editMetadata.unit
                                             </label>
                                             <div
-                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-egkSDF cnFbIu css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw hXgXvF css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
                                             >
                                               <input
                                                 aria-invalid="false"
@@ -409,7 +409,7 @@ exports[`Rendering test renders correctly 1`] = `
                                               editMetadata.source
                                             </label>
                                             <div
-                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-egkSDF cnFbIu css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw hXgXvF css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
                                             >
                                               <input
                                                 aria-invalid="false"
@@ -445,7 +445,7 @@ exports[`Rendering test renders correctly 1`] = `
                                         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-172kgz0-MuiPaper-root"
                                       >
                                         <div
-                                          class="MuiStack-root sc-fAUdSK geoqZq css-1sazv7p-MuiStack-root"
+                                          class="MuiStack-root sc-egkSDF emnLII css-1sazv7p-MuiStack-root"
                                         >
                                           <div
                                             class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
@@ -458,7 +458,7 @@ exports[`Rendering test renders correctly 1`] = `
                                               editMetadata.valueName: fgfgfg2
                                             </label>
                                             <div
-                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-egkSDF cnFbIu css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw hXgXvF css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
                                             >
                                               <input
                                                 aria-invalid="false"
@@ -495,7 +495,7 @@ exports[`Rendering test renders correctly 1`] = `
                                               editMetadata.unit
                                             </label>
                                             <div
-                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-egkSDF cnFbIu css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw hXgXvF css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
                                             >
                                               <input
                                                 aria-invalid="false"
@@ -532,7 +532,7 @@ exports[`Rendering test renders correctly 1`] = `
                                               editMetadata.source
                                             </label>
                                             <div
-                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-egkSDF cnFbIu css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtLWhw hXgXvF css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
                                             >
                                               <input
                                                 aria-invalid="false"
@@ -596,17 +596,17 @@ exports[`Rendering test renders correctly 1`] = `
       />
     </div>
     <div
-      class="sc-bbQqnZ fvGgYQ"
+      class="sc-uYFMi frXZCO"
     >
       <div
-        class="sc-iwXfZk eLohxM"
+        class="sc-bbQqnZ TfGjZ"
       >
         <div
-          class="sc-kZrBCu UnBut"
+          class="sc-dEkLRj fxMHYI"
         >
           <button
             aria-label="tooltip.open: tooltip.visualizationType"
-            class="sc-kLhKbu gOGwLg"
+            class="sc-ghWlax bEVwpO"
           >
             <svg
               aria-hidden="true"
@@ -621,7 +621,7 @@ exports[`Rendering test renders correctly 1`] = `
             </svg>
           </button>
           <div
-            class="sc-dEkLRj cNKyhM"
+            class="sc-iwXfZk jlKYLz"
           >
             <div
               aria-label="tooltip.visualizationType"
@@ -673,7 +673,7 @@ exports[`Rendering test renders correctly 1`] = `
           </button>
         </div>
         <div
-          class="sc-kZrBCu UnBut"
+          class="sc-dEkLRj fxMHYI"
         >
           <div
             aria-live="polite"
@@ -710,7 +710,7 @@ exports[`Rendering test renders correctly 1`] = `
     <div>
       <button
         aria-label="tooltip.open: tooltip.visualizationConfig"
-        class="sc-kLhKbu gOGwLg"
+        class="sc-ghWlax bEVwpO"
       >
         <svg
           aria-hidden="true"
@@ -725,7 +725,7 @@ exports[`Rendering test renders correctly 1`] = `
         </svg>
       </button>
       <div
-        class="sc-hJRrWL gQMOLi"
+        class="sc-geXuza kSUHpL"
       >
         <div
           class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
@@ -785,7 +785,7 @@ exports[`Rendering test renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="MuiStack-root sc-iuUfFv gFKHmF css-m69qwo-MuiStack-root"
+          class="MuiStack-root sc-gQaihK bDnXvj css-m69qwo-MuiStack-root"
         >
           <div
             class="MuiBox-root css-0"
@@ -797,7 +797,7 @@ exports[`Rendering test renders correctly 1`] = `
               chartSettings.markerScale
             </p>
             <span
-              class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-dprtRQ exiPCN css-ltlhnc-MuiSlider-root"
+              class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-iuUfFv GDLPf css-ltlhnc-MuiSlider-root"
             >
               <span
                 class="MuiSlider-rail css-7o8aqz-MuiSlider-rail"
@@ -884,7 +884,7 @@ exports[`Rendering test renders correctly 1`] = `
         </div>
       </div>
       <div
-        class="sc-hJRrWL gQMOLi"
+        class="sc-geXuza kSUHpL"
       >
         <div
           class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
@@ -917,7 +917,7 @@ exports[`Rendering test renders correctly 1`] = `
               class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
             >
               <p
-                class="MuiTypography-root MuiTypography-body1 sc-geXuza dPyjND css-ahj2mt-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 sc-eUlrpB hKLoeb css-ahj2mt-MuiTypography-root"
               >
                 chartSettings.cutYAxis
               </p>
@@ -925,7 +925,7 @@ exports[`Rendering test renders correctly 1`] = `
           </label>
         </div>
         <div
-          class="MuiFormControl-root MuiFormControl-fullWidth sc-eUlrpB jAkXxB css-q8hpuo-MuiFormControl-root"
+          class="MuiFormControl-root MuiFormControl-fullWidth sc-dprtRQ cKIcwc css-q8hpuo-MuiFormControl-root"
         >
           <label
             class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
@@ -955,7 +955,7 @@ exports[`Rendering test renders correctly 1`] = `
               class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
             >
               <p
-                class="MuiTypography-root MuiTypography-body1 sc-geXuza dPyjND css-ahj2mt-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 sc-eUlrpB hKLoeb css-ahj2mt-MuiTypography-root"
               >
                 chartSettings.matchXLabelsToEnd
               </p>
@@ -993,7 +993,7 @@ exports[`Rendering test renders correctly 1`] = `
               class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
             >
               <p
-                class="MuiTypography-root MuiTypography-body1 sc-geXuza dPyjND css-ahj2mt-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 sc-eUlrpB hKLoeb css-ahj2mt-MuiTypography-root"
               >
                 visualizationSettings.showDataPoints
               </p>

--- a/PxGraf.Frontend/src/views/TableListSelection/__snapshots__/TableListSelection.test.tsx.snap
+++ b/PxGraf.Frontend/src/views/TableListSelection/__snapshots__/TableListSelection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthMd sc-geoRQH eCDxEt css-xdmu94-MuiContainer-root"
+    class="MuiContainer-root MuiContainer-maxWidthMd sc-ikngxL epXKmY css-xdmu94-MuiContainer-root"
   >
     <ul
       class="MuiList-root MuiList-padding css-822hb5-MuiList-root"

--- a/PxGraf.Frontend/src/views/TableTreeSelection/__snapshots__/TableTreeSelection.test.tsx.snap
+++ b/PxGraf.Frontend/src/views/TableTreeSelection/__snapshots__/TableTreeSelection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthMd sc-ikngxL epXKmY css-xdmu94-MuiContainer-root"
+    class="MuiContainer-root MuiContainer-maxWidthMd sc-gFtjaa jCFGXo css-xdmu94-MuiContainer-root"
   >
     <nav
       aria-labelledby="nested-list-subheader"
@@ -14,7 +14,7 @@ exports[`Rendering test renders correctly 1`] = `
         id="nested-list-subheader"
       >
         <div
-          class="sc-geoRQH hVeCix"
+          class="sc-ikngxL ELzjk"
         >
           <div>
             tableSelect.title
@@ -39,7 +39,7 @@ exports[`Rendering test renders correctly 1`] = `
         </div>
       </div>
       <li
-        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-hGNhLO fnYyPb css-1p823my-MuiListItem-root"
+        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-khdDuB jYEFrN css-1p823my-MuiListItem-root"
         id="id1.px"
       >
         <a
@@ -85,7 +85,7 @@ exports[`Rendering test renders correctly 1`] = `
         class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
       />
       <li
-        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-hGNhLO fnYyPb css-1p823my-MuiListItem-root"
+        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-khdDuB jYEFrN css-1p823my-MuiListItem-root"
         id="id2.px"
       >
         <a


### PR DESCRIPTION
Use conditional styling for editorfield component input fields based on whether they were edited. This solves the lost focus issue