### PR TITLE
Fixed issues with monolingual tables

### DIFF
--- a/PxGraf/ChartTypeSelection/VisualizationTypeSelectionObject.cs
+++ b/PxGraf/ChartTypeSelection/VisualizationTypeSelectionObject.cs
@@ -41,11 +41,11 @@ namespace PxGraf.ChartTypeSelection
 
         public static VisualizationTypeSelectionObject FromQueryAndMatrix(MatrixQuery query, Matrix<DecimalDataValue> matrix)
         {
-            List<DimensionInfo> dimInfos = matrix.Metadata.Dimensions.Select(v =>
+            List<DimensionInfo> dimInfos = [.. matrix.Metadata.Dimensions.Select(v =>
             {
                 DimensionQuery dimQuery = query.DimensionQueries[v.Code];
                 return DimensionInfo.FromQueryAndDimension(dimQuery, v);
-            }).ToList();
+            })];
 
             VisualizationTypeSelectionObject result = new(dimInfos);
 

--- a/PxGraf/Controllers/CreationController.cs
+++ b/PxGraf/Controllers/CreationController.cs
@@ -63,7 +63,7 @@ namespace PxGraf.Controllers
             // If listing databases, filter out databases that are not whitelisted
             if (hierarchy.Length == 0 && databaseWhitelist.Length > 0)
             {
-                List<DatabaseGroupHeader> filteredHeaders = result.Headers.Where(header => PathUtils.IsDatabaseWhitelisted(header.Code, databaseWhitelist)).ToList();
+                List<DatabaseGroupHeader> filteredHeaders = [.. result.Headers.Where(header => PathUtils.IsDatabaseWhitelisted(header.Code, databaseWhitelist))];
                 _logger.LogDebug("data-bases/{DbPath} result: {Result}", dbPath, result);
                 return new DatabaseGroupContents(filteredHeaders, result.Files);
             }
@@ -164,7 +164,7 @@ namespace PxGraf.Controllers
                     if (tableMeta.Dimensions.FirstOrDefault(dimension => dimension.Code == filter.Key) is IReadOnlyDimension dimension)
                     {
                         IEnumerable<IReadOnlyDimensionValue> filteredValues = filter.Value.Filter(dimension.Values);
-                        List<string> filteredValueCodes = filteredValues.Select(value => value.Code).ToList();
+                        List<string> filteredValueCodes = [.. filteredValues.Select(value => value.Code)];
                         _logger.LogDebug("filter-dimension result: {FilteredValueCodes}", filteredValueCodes);
                         return filteredValueCodes;
                     }
@@ -211,7 +211,7 @@ namespace PxGraf.Controllers
             Matrix<DecimalDataValue> matrix = await _datasource.GetMatrixCachedAsync(cubeQuery.TableReference, filteredMeta);
 
             IReadOnlyList<VisualizationType> validTypes = ChartTypeSelector.Selector.GetValidChartTypes(cubeQuery, matrix);
-            List<string> validTypesList = validTypes.Select(ChartTypeEnumConverter.ToJsonString).ToList();
+            List<string> validTypesList = [.. validTypes.Select(ChartTypeEnumConverter.ToJsonString)];
             _logger.LogDebug("valid-visualizations result: {ValidTypesList}", validTypesList);
             return validTypesList;
         }

--- a/PxGraf/Controllers/SqController.cs
+++ b/PxGraf/Controllers/SqController.cs
@@ -6,7 +6,6 @@ using Px.Utils.Models.Metadata.Enums;
 using Px.Utils.Models.Metadata;
 using Px.Utils.Models;
 using PxGraf.ChartTypeSelection;
-using PxGraf.Datasource.PxWebInterface;
 using PxGraf.Datasource;
 using PxGraf.Enums;
 using PxGraf.Exceptions;

--- a/PxGraf/Data/CubeSorting.cs
+++ b/PxGraf/Data/CubeSorting.cs
@@ -87,8 +87,7 @@ namespace PxGraf.Data
         private static List<SortingOption> GetMultiDimHorizontalBarChartOptions(VisualizationType visualization, IReadOnlyMatrixMetadata meta, VisualizationSettingsRequest request)
         {
             // Selectable dimensions are excluded from sorting, OBS: '!'
-            List<IReadOnlyDimension> multiselects = meta.GetMultivalueDimensions()
-                .Where(mvv => !request.Query.DimensionQueries[mvv.Code].Selectable).ToList();
+            List<IReadOnlyDimension> multiselects = [.. meta.GetMultivalueDimensions().Where(mvv => !request.Query.DimensionQueries[mvv.Code].Selectable)];
             IReadOnlyDimension sortingOptionsDimension = GetPivot(visualization, meta, request) ? multiselects[1] : multiselects[0];
 
             List<SortingOption> options = [.. GetDimensionSortingOptions(sortingOptionsDimension)];

--- a/PxGraf/Data/LayoutRules.cs
+++ b/PxGraf/Data/LayoutRules.cs
@@ -24,9 +24,7 @@ namespace PxGraf.Data
 
         public static Layout GetTwoDimensionalLayout(bool pivotRequested, VisualizationType visualizationType, IReadOnlyMatrixMetadata meta, MatrixQuery query)
         {
-            IReadOnlyDimension[] multiValueDims = meta.GetMultivalueDimensions()
-                .Where(v => !query.DimensionQueries[v.Code].Selectable)
-                .ToArray();
+            IReadOnlyDimension[] multiValueDims = [.. meta.GetMultivalueDimensions().Where(v => !query.DimensionQueries[v.Code].Selectable)];
 
             Debug.Assert(multiValueDims.Length == 2);
 
@@ -50,9 +48,7 @@ namespace PxGraf.Data
 
         public static Layout GetLineChartLayout(IReadOnlyMatrixMetadata meta, MatrixQuery query)
         {
-            IReadOnlyDimension[] multiValueDims = meta.GetMultivalueDimensions()
-                .Where(v => !query.DimensionQueries[v.Code].Selectable)
-                .ToArray();
+            IReadOnlyDimension[] multiValueDims = [.. meta.GetMultivalueDimensions().Where(v => !query.DimensionQueries[v.Code].Selectable)];
 
             // Prefer time dimension over ordinal dimension
             IReadOnlyDimension multiValueTimeDimension = Array.Find(multiValueDims, v => v.Type == DimensionType.Time);
@@ -62,7 +58,7 @@ namespace PxGraf.Data
                     .First(v => v.Type == DimensionType.Ordinal).Code;
 
             return new Layout(
-                multiValueDims.Select(d => d.Code).Where(vc => vc != columnDimensionCode).ToList(),
+                [.. multiValueDims.Select(d => d.Code).Where(vc => vc != columnDimensionCode)],
                 [columnDimensionCode]);
         }
 

--- a/PxGraf/Datasource/ApiDatasource/CachedApiDatasource.cs
+++ b/PxGraf/Datasource/ApiDatasource/CachedApiDatasource.cs
@@ -3,7 +3,6 @@ using Px.Utils.Models.Data.DataValue;
 using Px.Utils.Models.Metadata;
 using Px.Utils.Models;
 using PxGraf.Datasource.Cache;
-using PxGraf.Datasource.PxWebInterface;
 using PxGraf.Models.Metadata;
 using PxGraf.Models.Queries;
 using PxGraf.Models.Responses.DatabaseItems;

--- a/PxGraf/Datasource/ApiDatasource/IApiDatasource.cs
+++ b/PxGraf/Datasource/ApiDatasource/IApiDatasource.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using System.Threading;
 using System;
 
-namespace PxGraf.Datasource.PxWebInterface
+namespace PxGraf.Datasource.ApiDatasource
 {
     /// <summary>
     /// Interface for accessing data from the PxWeb API.

--- a/PxGraf/Datasource/ApiDatasource/IPxWebConnection.cs
+++ b/PxGraf/Datasource/ApiDatasource/IPxWebConnection.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace PxGraf.Datasource.PxWebInterface
+namespace PxGraf.Datasource.ApiDatasource
 {
     /// <summary>
     /// Interface for a connection to PxWeb.

--- a/PxGraf/Datasource/ApiDatasource/PxWebConnection.cs
+++ b/PxGraf/Datasource/ApiDatasource/PxWebConnection.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System;
 
-namespace PxGraf.Datasource.PxWebInterface
+namespace PxGraf.Datasource.ApiDatasource
 {
     [ExcludeFromCodeCoverage] // HTTP client object can not be mocked with reasonable effort
     public class PxWebConnection(IHttpClientFactory clientFactory) : IPxWebConnection

--- a/PxGraf/Datasource/ApiDatasource/PxWebV1ApiInterface.cs
+++ b/PxGraf/Datasource/ApiDatasource/PxWebV1ApiInterface.cs
@@ -8,8 +8,6 @@ using Px.Utils.Models.Metadata.MetaProperties;
 using Px.Utils.Models.Metadata;
 using Px.Utils.Models;
 using PxGraf.Datasource.ApiDatasource.SerializationModels;
-using PxGraf.Datasource.PxWebInterface.SerializationModels;
-using PxGraf.Datasource.PxWebInterface;
 using PxGraf.Exceptions;
 using PxGraf.Models.Queries;
 using PxGraf.Models.Responses.DatabaseItems;
@@ -23,6 +21,8 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using System.Threading;
 using System;
+
+
 
 #if DEBUG
 using System.Diagnostics;
@@ -196,7 +196,7 @@ namespace PxGraf.Datasource.ApiDatasource
             foreach (string dimensionId in dataResult.Id)
             {
                 JsonStat2.DimensionObj dimension = dataResult.Dimensions[dimensionId];
-                List<string> dimensionValueCodes = new(new string[dimension.Category.Index.Count]);
+                List<string> dimensionValueCodes = [.. new string[dimension.Category.Index.Count]];
 
                 foreach (KeyValuePair<string, int> p in dimension.Category.Index)
                 {
@@ -386,7 +386,7 @@ namespace PxGraf.Datasource.ApiDatasource
         {
             return new PxWebDataQueryPostParams()
             {
-                Query = queries.ToArray(),
+                Query = [.. queries],
                 Response = new PxWebDataQueryPostParams.ResponseInfo()
                 {
                     Format = "json-stat2"

--- a/PxGraf/Datasource/ApiDatasource/SerializationModels/ModelExtensions.cs
+++ b/PxGraf/Datasource/ApiDatasource/SerializationModels/ModelExtensions.cs
@@ -1,6 +1,4 @@
-﻿using PxGraf.Datasource.ApiDatasource.SerializationModels;
-
-namespace PxGraf.Datasource.PxWebInterface.SerializationModels
+﻿namespace PxGraf.Datasource.ApiDatasource.SerializationModels
 {
     public static class ModelExtensions
     {

--- a/PxGraf/Datasource/ApiDatasource/SerializationModels/PxMetaResponse.cs
+++ b/PxGraf/Datasource/ApiDatasource/SerializationModels/PxMetaResponse.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace PxGraf.Datasource.PxWebInterface.SerializationModels
+namespace PxGraf.Datasource.ApiDatasource.SerializationModels
 {
     public class PxMetaResponse : IMatrixMap
     {

--- a/PxGraf/Datasource/ApiDatasource/SerializationModels/PxWebDataQueryPostParams.cs
+++ b/PxGraf/Datasource/ApiDatasource/SerializationModels/PxWebDataQueryPostParams.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace PxGraf.Datasource.PxWebInterface.SerializationModels
+namespace PxGraf.Datasource.ApiDatasource.SerializationModels
 {
     public class PxWebDataQueryPostParams
     {

--- a/PxGraf/Datasource/ApiDatasource/SerializationModels/PxWebError.cs
+++ b/PxGraf/Datasource/ApiDatasource/SerializationModels/PxWebError.cs
@@ -1,4 +1,4 @@
-﻿namespace PxGraf.Datasource.PxWebInterface.SerializationModels
+﻿namespace PxGraf.Datasource.ApiDatasource.SerializationModels
 {
     public class PxWebError
     {

--- a/PxGraf/Datasource/FileDatasource/CachedFileDatasource.cs
+++ b/PxGraf/Datasource/FileDatasource/CachedFileDatasource.cs
@@ -6,7 +6,6 @@ using Px.Utils.Models.Data.DataValue;
 using Px.Utils.Models.Metadata;
 using Px.Utils.Models.Metadata.MetaProperties;
 using PxGraf.Datasource.Cache;
-using PxGraf.Datasource.DatabaseConnection;
 using PxGraf.Models.Metadata;
 using PxGraf.Models.Queries;
 using PxGraf.Models.Responses.DatabaseItems;

--- a/PxGraf/Datasource/FileDatasource/IFileDatasource.cs
+++ b/PxGraf/Datasource/FileDatasource/IFileDatasource.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace PxGraf.Datasource.DatabaseConnection
+namespace PxGraf.Datasource.FileDatasource
 {
     public interface IFileDatasource
     {

--- a/PxGraf/Datasource/FileDatasource/LocalFilesystemDatabase.cs
+++ b/PxGraf/Datasource/FileDatasource/LocalFilesystemDatabase.cs
@@ -132,6 +132,7 @@ namespace PxGraf.Datasource.FileDatasource
             MatrixMetadata meta = await builder.BuildAsync(entries);
             AssignOrdinalDimensionTypes(meta);
             AssignSourceToContentDimensionValues(meta);
+            AssignLanguageToSingleLangProperties(meta, [PxSyntaxConstants.NOTE_KEY, PxSyntaxConstants.VALUENOTE_KEY]);
             return meta;
         }
 
@@ -192,6 +193,42 @@ namespace PxGraf.Datasource.FileDatasource
 
                 meta.AdditionalProperties.Remove(PxSyntaxConstants.SOURCE_KEY);
                 contentDimension.AdditionalProperties.Remove(PxSyntaxConstants.SOURCE_KEY);
+            }
+        }
+
+        private static void AssignLanguageToSingleLangProperties(MatrixMetadata meta, List<string> keys)
+        {
+            // Table level
+            foreach(string key in keys)
+            {
+                if (meta.AdditionalProperties.TryGetValue(key, out MetaProperty? prop))
+                {
+                    meta.AdditionalProperties[key] = prop.AsMultiLanguageProperty(meta.DefaultLanguage);
+                }
+            }
+
+            foreach (Dimension dim in meta.Dimensions)
+            {
+                // Dimension level
+                foreach (string key in keys)
+                {
+                    if (dim.AdditionalProperties.TryGetValue(key, out MetaProperty? prop))
+                    {
+                        dim.AdditionalProperties[key] = prop.AsMultiLanguageProperty(meta.DefaultLanguage);
+                    }
+                }
+
+                // Dimension value level
+                foreach (DimensionValue val in dim.Values)
+                {
+                    foreach (string key in keys)
+                    {
+                        if (val.AdditionalProperties.TryGetValue(key, out MetaProperty? prop))
+                        {
+                            val.AdditionalProperties[key] = prop.AsMultiLanguageProperty(meta.DefaultLanguage);
+                        }
+                    }
+                }
             }
         }
 

--- a/PxGraf/Datasource/FileDatasource/LocalFilesystemDatabase.cs
+++ b/PxGraf/Datasource/FileDatasource/LocalFilesystemDatabase.cs
@@ -1,27 +1,26 @@
 ﻿#nullable enable
 using Px.Utils.Language;
 using Px.Utils.ModelBuilders;
-using Px.Utils.Models;
 using Px.Utils.Models.Data.DataValue;
-using Px.Utils.Models.Metadata;
 using Px.Utils.Models.Metadata.Dimensions;
 using Px.Utils.Models.Metadata.Enums;
 using Px.Utils.Models.Metadata.ExtensionMethods;
 using Px.Utils.Models.Metadata.MetaProperties;
+using Px.Utils.Models.Metadata;
+using Px.Utils.Models;
 using Px.Utils.PxFile.Data;
 using Px.Utils.PxFile.Metadata;
-using PxGraf.Datasource.DatabaseConnection;
 using PxGraf.Models.Queries;
 using PxGraf.Models.Responses.DatabaseItems;
 using PxGraf.Utility;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
+using System.Threading;
+using System;
 
 namespace PxGraf.Datasource.FileDatasource
 {
@@ -167,22 +166,23 @@ namespace PxGraf.Datasource.FileDatasource
         {
             if (meta.TryGetContentDimension(out ContentDimension? contentDimension))
             {
+                string defaultLang = meta.DefaultLanguage;
                 foreach (ContentDimensionValue cdv in contentDimension.Values)
                 {
                     // Primarily use source information from the content dimension value.
-                    if (cdv.AdditionalProperties.ContainsKey(PxSyntaxConstants.SOURCE_KEY)) continue;
-
-                    // If the value has no source, use the source of the content dimension.
-                    if (contentDimension.AdditionalProperties.TryGetValue(PxSyntaxConstants.SOURCE_KEY, out MetaProperty? prop) &&
-                        prop is MultilanguageStringProperty dimMlsp)
+                    if (cdv.AdditionalProperties.TryGetValue(PxSyntaxConstants.SOURCE_KEY, out MetaProperty? valueProp))
                     {
-                        cdv.AdditionalProperties.TryAdd(PxSyntaxConstants.SOURCE_KEY, dimMlsp);
+                        cdv.AdditionalProperties[PxSyntaxConstants.SOURCE_KEY] = valueProp.AsMultiLanguageProperty(defaultLang);
+                    }
+                    // If the value has no source, use the source of the content dimension.
+                    else if (contentDimension.AdditionalProperties.TryGetValue(PxSyntaxConstants.SOURCE_KEY, out MetaProperty? dimProp))
+                    {
+                        cdv.AdditionalProperties.TryAdd(PxSyntaxConstants.SOURCE_KEY, dimProp.AsMultiLanguageProperty(defaultLang));
                     }
                     // If the dimension has no source, use the source of the table.
-                    else if (meta.AdditionalProperties.TryGetValue(PxSyntaxConstants.SOURCE_KEY, out MetaProperty? tableProp) &&
-                        tableProp is MultilanguageStringProperty tableMlsp)
+                    else if (meta.AdditionalProperties.TryGetValue(PxSyntaxConstants.SOURCE_KEY, out MetaProperty? tableProp))
                     {
-                        cdv.AdditionalProperties.TryAdd(PxSyntaxConstants.SOURCE_KEY, tableMlsp);
+                        cdv.AdditionalProperties.TryAdd(PxSyntaxConstants.SOURCE_KEY, tableProp.AsMultiLanguageProperty(defaultLang));
                     }
                     else
                     {

--- a/PxGraf/Datasource/FileDatasource/LocalFilesystemDatabaseConfig.cs
+++ b/PxGraf/Datasource/FileDatasource/LocalFilesystemDatabaseConfig.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text;
 
-namespace PxGraf.Datasource.DatabaseConnection
+namespace PxGraf.Datasource.FileDatasource
 {
     public class LocalFilesystemDatabaseConfig(bool enabled, string databaseRootPath, Encoding encoding, string[] databaseWhitelist)
     {

--- a/PxGraf/Datasource/FileDatasource/PathUtils.cs
+++ b/PxGraf/Datasource/FileDatasource/PathUtils.cs
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-using PxGraf.Datasource.DatabaseConnection;
 using PxGraf.Models.Queries;
 using System;
 using System.Collections.Generic;

--- a/PxGraf/Models/Metadata/DimensionExtensions.cs
+++ b/PxGraf/Models/Metadata/DimensionExtensions.cs
@@ -35,13 +35,15 @@ namespace PxGraf.Models.Metadata
         /// </summary>
         /// <param name="dimension">The dimension to search the property from.</param>
         /// <param name="propertyKey">The key of the property to search for.</param>
+        /// <param name="backUpLang">For single language objects backup language is required.</param>
         /// <returns></returns>
-        public static MultilanguageString? GetMultilanguageDimensionProperty(this IReadOnlyDimension dimension, string propertyKey)
+        public static MultilanguageString? GetMultilanguageDimensionProperty(this IReadOnlyDimension dimension, string propertyKey, string backUpLang)
         {
-            if (dimension.AdditionalProperties.TryGetValue(propertyKey, out MetaProperty? prop) &&
-                prop is MultilanguageStringProperty mlsProp) 
+            if (dimension.AdditionalProperties.TryGetValue(propertyKey, out MetaProperty? prop))
             {
-                return mlsProp.Value;
+                if (prop is MultilanguageStringProperty mlsProp) return mlsProp.Value;
+                else if (prop is StringProperty sProp) return new MultilanguageString(sProp.Value, backUpLang);
+                else return null;
             }
             else return null;
         }

--- a/PxGraf/Models/Metadata/HeaderBuildingUtilities.cs
+++ b/PxGraf/Models/Metadata/HeaderBuildingUtilities.cs
@@ -75,12 +75,11 @@ namespace PxGraf.Models.Metadata
                     langToHeader[language].AppendTimeValuePlaceholders(translation, timeDim.Values.Count > 1);
                 }
 
-                List<string> dimensionTexts = dimensions
+                List<string> dimensionTexts = [.. dimensions
                     .Where(v => v.Type != DimensionType.Time && v.Values.Count > 1)
                     // We want content dimension appear at the beginning [orderBy is stable so otherwise original order is maintained]
                     .OrderBy(v => v.Type == DimensionType.Content ? 0 : 1)
-                    .Select(v => GetDimensionNameEditForLanguage(query, v, language))
-                    .ToList();
+                    .Select(v => GetDimensionNameEditForLanguage(query, v, language))];
 
                 if (dimensionTexts.Count == 1)
                 {

--- a/PxGraf/Models/Metadata/MatrixMetadataExtensions.cs
+++ b/PxGraf/Models/Metadata/MatrixMetadataExtensions.cs
@@ -26,7 +26,7 @@ namespace PxGraf.Models.Metadata
             foreach (IReadOnlyDimension dimension in input.Dimensions)
             {
                 IValueFilter filter = query.DimensionQueries[dimension.Code].ValueFilter;
-                List<string> valueCodes = filter.Filter(dimension.Values).Select(v => v.Code).ToList();
+                List<string> valueCodes = [.. filter.Filter(dimension.Values).Select(v => v.Code)];
                 dimensionMaps.Add(new DimensionMap(dimension.Code, valueCodes));
             }
             return input.GetTransform(new MatrixMap(dimensionMaps));
@@ -46,9 +46,7 @@ namespace PxGraf.Models.Metadata
         /// </summary>
         public static IReadOnlyList<IReadOnlyDimension> GetMultivalueDimensions(this IReadOnlyMatrixMetadata cubeMeta)
         {
-            return cubeMeta.Dimensions
-                .Where(dimension => dimension.Values.Count > 1)
-                .ToList();
+            return [.. cubeMeta.Dimensions.Where(dimension => dimension.Values.Count > 1)];
         }
 
         /// <summary>
@@ -56,9 +54,7 @@ namespace PxGraf.Models.Metadata
         /// </summary>
         public static IReadOnlyList<IReadOnlyDimension> GetSinglevalueDimensions(this IReadOnlyMatrixMetadata cubeMeta)
         {
-            return cubeMeta.Dimensions
-                .Where(dimension => dimension.Values.Count == 1)
-                .ToList();
+            return [.. cubeMeta.Dimensions.Where(dimension => dimension.Values.Count == 1)];
         }
 
         /// <summary>

--- a/PxGraf/Models/Metadata/PxGrafMetaExtensions.cs
+++ b/PxGraf/Models/Metadata/PxGrafMetaExtensions.cs
@@ -30,7 +30,7 @@ namespace PxGraf.Models.Metadata
                 matrixProperties[PxSyntaxConstants.NOTE_KEY] = new MultilanguageStringProperty(new(note));
             }
 
-            List<Dimension> dimensions = pxGrafMeta.Variables.Select(v => v.ConvertToDimension()).ToList();
+            List<Dimension> dimensions = [.. pxGrafMeta.Variables.Select(v => v.ConvertToDimension())];
             string defaultLang = pxGrafMeta.GetDefaultLanguage();
             MatrixMetadata meta = new(defaultLang, pxGrafMeta.Languages, dimensions, matrixProperties);
             return meta;
@@ -95,7 +95,7 @@ namespace PxGraf.Models.Metadata
                     DimensionValue tdv = new(dimValue.Code, dimValue.Name);
                     values.Add(tdv);
                 }
-                TimeDimensionInterval intervals = TimeDimensionIntervalParser.DetermineIntervalFromCodes(values.Select(v => v.Code).ToList());
+                TimeDimensionInterval intervals = TimeDimensionIntervalParser.DetermineIntervalFromCodes([.. values.Select(v => v.Code)]);
                 return new TimeDimension(input.Code, input.Name, dimensionProperties, values, intervals);
             }
             else

--- a/PxGraf/PxGraf.csproj
+++ b/PxGraf/PxGraf.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>PxGraf</AssemblyName>
     <UserSecretsId>5fefcbdc-e04e-4475-9927-aab412b027ff</UserSecretsId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>4.0.9</VersionPrefix>
+    <VersionPrefix>4.0.10</VersionPrefix>
 	<SpaRoot>..\PxGraf.Frontend</SpaRoot>
 	<Configurations>Debug;Release;Test</Configurations>
   </PropertyGroup>

--- a/PxGraf/Settings/Configuration.cs
+++ b/PxGraf/Settings/Configuration.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
-using PxGraf.Datasource.DatabaseConnection;
+using PxGraf.Datasource.FileDatasource;
 using System.Collections.Generic;
 using System.Text;
 

--- a/PxGraf/Startup.cs
+++ b/PxGraf/Startup.cs
@@ -15,8 +15,6 @@ using System.Linq;
 using System.Net.Http;
 using System;
 using PxGraf.Datasource;
-using PxGraf.Datasource.PxWebInterface;
-using PxGraf.Datasource.DatabaseConnection;
 using PxGraf.Datasource.Cache;
 using PxGraf.Models.Queries;
 using PxGraf.Datasource.FileDatasource;

--- a/PxGraf/Utility/MetaPropertyExtensions.cs
+++ b/PxGraf/Utility/MetaPropertyExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Px.Utils.Models.Metadata.MetaProperties;
+using System;
+
+namespace PxGraf.Utility
+{
+    public static class MetaPropertyExtensions
+    {
+        public static MultilanguageStringProperty AsMultiLanguageProperty(this MetaProperty property, string lang)
+        {
+            if (property is MultilanguageStringProperty mlsp) return mlsp;
+            else if (property is StringProperty sp) return new MultilanguageStringProperty(new(lang, sp.Value));
+            else throw new ArgumentException($"Property of type {property.GetType()} can not be converted to multilanguage string property.");
+        }
+    }
+}

--- a/PxGraf/Utility/UtilityFunctions.cs
+++ b/PxGraf/Utility/UtilityFunctions.cs
@@ -48,7 +48,7 @@ namespace PxGraf.Utility
         /// </summary>
         public static T UnambiguousOrDefault<T>(IEnumerable<T> items)
         {
-            List<T> uniqueItems = items.Distinct().ToList();
+            List<T> uniqueItems = [.. items.Distinct()];
             if (uniqueItems.Count == 1)
             {
                 return uniqueItems[0];

--- a/PxGraf/Visualization/PxVisualizerCubeAdapter.cs
+++ b/PxGraf/Visualization/PxVisualizerCubeAdapter.cs
@@ -67,12 +67,11 @@ namespace PxGraf.Visualization
             DimensionLayout layout = GetDimensionLayout(matrix.Metadata, query, settings);
 
             MatrixMap finalMap = new(
-                layout.SingleValueDimensions
+                [.. layout.SingleValueDimensions
                     .Concat(layout.SelectableDimensionCodes)
                     .Concat(layout.RowDimensionCodes)
                     .Concat(layout.ColumnDimensionCodes)
-                    .Select(vc => matrix.Metadata.DimensionMaps.First(vm => vm.Code == vc))
-                    .ToList()
+                    .Select(vc => matrix.Metadata.DimensionMaps.First(vm => vm.Code == vc))]
                 );
 
             Matrix<DecimalDataValue> resultMatrix = matrix.GetTransform(finalMap);
@@ -108,7 +107,7 @@ namespace PxGraf.Visualization
         
         private static List<Variable> BuildVariableList(Dictionary<string, DimensionQuery> dimensionQueries, IReadOnlyMatrixMetadata meta)
         {
-            return meta.Dimensions.Select(dimension =>
+            return [.. meta.Dimensions.Select(dimension =>
             {
                 MultilanguageString name = dimension.Name;
                 if (dimensionQueries.TryGetValue(dimension.Code, out DimensionQuery query) &&
@@ -120,19 +119,18 @@ namespace PxGraf.Visualization
                 return new Variable(
                     code: dimension.Code,
                     name: name,
-                    note: dimension.GetMultilanguageDimensionProperty(PxSyntaxConstants.NOTE_KEY),
+                    note: dimension.GetMultilanguageDimensionProperty(PxSyntaxConstants.NOTE_KEY, meta.DefaultLanguage),
                     type: dimension.Type,
-                    values: dimension.Values.Select(v => v
-                        .ConvertToVariableValue(dimension.GetEliminationValueCode(), query))
-                        .ToList()
+                    values: [.. dimension.Values.Select(v =>
+                        v.ConvertToVariableValue(dimension.GetEliminationValueCode(), query))]
                     );
-            }).ToList();
+            })];
         }
 
         private static DimensionLayout GetDimensionLayout(IReadOnlyMatrixMetadata meta, MatrixQuery query, VisualizationSettings settings)
         {
             DimensionLayout layout = new();
-            List<string> remainingVars = meta.Dimensions.Select(v => v.Code).ToList();
+            List<string> remainingVars = [.. meta.Dimensions.Select(v => v.Code)];
 
             // Selectables are added first from multivalue dimensions, so that the data from each selection is grouped together
             foreach (string code in query.DimensionQueries

--- a/UnitTests/ControllerTests/CreationControllerTests/GetVisualizationRulesAsyncActionTests.cs
+++ b/UnitTests/ControllerTests/CreationControllerTests/GetVisualizationRulesAsyncActionTests.cs
@@ -94,7 +94,7 @@ namespace UnitTests.ControllerTests.CreationControllerTests
             };
 
             ActionResult<VisualizationRules> actionResult = await testController.GetVisualizationRulesAsync(rulesRequest);
-            List<string> sortingOptionCodes = actionResult.Value.SortingOptions.Select(so => so.Code).ToList();
+            List<string> sortingOptionCodes = [.. actionResult.Value.SortingOptions.Select(so => so.Code)];
             List<string> expected = ["descending", "ascending", "no_sorting", "reversed"];
             Assert.That(sortingOptionCodes, Is.EqualTo(expected));
         }
@@ -130,7 +130,7 @@ namespace UnitTests.ControllerTests.CreationControllerTests
             };
 
             ActionResult<VisualizationRules> actionResult = await testController.GetVisualizationRulesAsync(rulesRequest);
-            List<string> sortingOptionCodes = actionResult.Value.SortingOptions.Select(so => so.Code).ToList();
+            List<string> sortingOptionCodes = [.. actionResult.Value.SortingOptions.Select(so => so.Code)];
             List<string> expected = ["value-0", "value-1", "value-2", "value-3", "sum", "no_sorting", "reversed"];
             Assert.That(sortingOptionCodes, Is.EqualTo(expected));
         }
@@ -166,7 +166,7 @@ namespace UnitTests.ControllerTests.CreationControllerTests
             };
 
             ActionResult<VisualizationRules> actionResult = await testController.GetVisualizationRulesAsync(rulesRequest);
-            List<string> sortingOptionCodes = actionResult.Value.SortingOptions.Select(so => so.Code).ToList();
+            List<string> sortingOptionCodes = [.. actionResult.Value.SortingOptions.Select(so => so.Code)];
             List<string> expected = ["value-0", "value-1", "value-2", "sum", "no_sorting", "reversed"];
             Assert.That(sortingOptionCodes, Is.EqualTo(expected));
         }

--- a/UnitTests/ControllerTests/ErrorControllerTests.cs
+++ b/UnitTests/ControllerTests/ErrorControllerTests.cs
@@ -5,10 +5,10 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using PxGraf.Controllers;
-using System;
 using System.IO;
+using System;
 
-namespace UnitTests.ControllerTests.ErrorControllerTests
+namespace UnitTests.ControllerTests
 {
     internal class ErrorControllerTests
     {

--- a/UnitTests/DatasourceTests/CachedApiDataSourceTests.cs
+++ b/UnitTests/DatasourceTests/CachedApiDataSourceTests.cs
@@ -9,7 +9,6 @@ using Px.Utils.Models.Metadata;
 using Px.Utils.Models;
 using PxGraf.Datasource.ApiDatasource;
 using PxGraf.Datasource.Cache;
-using PxGraf.Datasource.PxWebInterface;
 using PxGraf.Models.Queries;
 using PxGraf.Models.Responses.DatabaseItems;
 using PxGraf.Settings;

--- a/UnitTests/DatasourceTests/CachedFileDatasourceTests.cs
+++ b/UnitTests/DatasourceTests/CachedFileDatasourceTests.cs
@@ -10,7 +10,6 @@ using Px.Utils.Models.Metadata.MetaProperties;
 using Px.Utils.Models.Metadata;
 using Px.Utils.Models;
 using PxGraf.Datasource.Cache;
-using PxGraf.Datasource.DatabaseConnection;
 using PxGraf.Datasource.FileDatasource;
 using PxGraf.Models.Queries;
 using PxGraf.Models.Responses.DatabaseItems;

--- a/UnitTests/DatasourceTests/PathUtilsTests.cs
+++ b/UnitTests/DatasourceTests/PathUtilsTests.cs
@@ -1,11 +1,9 @@
 ﻿using NUnit.Framework;
-using PxGraf.Datasource.DatabaseConnection;
 using PxGraf.Datasource.FileDatasource;
 using PxGraf.Models.Queries;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace UnitTests.DatasourceTests
 {

--- a/UnitTests/DatasourceTests/PxWebV1ApiInterfaceTests.cs
+++ b/UnitTests/DatasourceTests/PxWebV1ApiInterfaceTests.cs
@@ -9,7 +9,6 @@ using Px.Utils.Models.Metadata.Dimensions;
 using Px.Utils.Models.Metadata.Enums;
 using Px.Utils.Models.Metadata;
 using Px.Utils.Models;
-using PxGraf.Datasource.PxWebInterface;
 using PxGraf.Models.Queries;
 using PxGraf.Models.Responses.DatabaseItems;
 using PxGraf.Settings;
@@ -224,7 +223,7 @@ namespace UnitTests.DatasourceTests
             };
             mockConnection.Setup(mc => mc.PostAsync("api/v1/sv/mock/table/reference/FooBar", It.IsAny<string>())).ReturnsAsync(mockJsonStatResponseSv);
 
-            IEnumerable<string> expectedLangs = new[] { "en", "fi", "sv" };
+            IEnumerable<string> expectedLangs = ["en", "fi", "sv"];
             Dictionary<string, string> expectedUnitValues = new()
             {
                 ["en"] = "unit.en",
@@ -345,7 +344,7 @@ namespace UnitTests.DatasourceTests
 
             // Assert
             Assert.That(matrix, Is.InstanceOf<Matrix<DecimalDataValue>>());
-            decimal[] decimals = matrix.Data.Select(dv => dv.UnsafeValue).ToArray();
+            decimal[] decimals = [.. matrix.Data.Select(dv => dv.UnsafeValue)];
             Assert.That(decimals, Is.EqualTo(expectedData));
         }
 

--- a/UnitTests/MatrixMetadataTests/DimensionExtensionsTests.cs
+++ b/UnitTests/MatrixMetadataTests/DimensionExtensionsTests.cs
@@ -79,7 +79,7 @@ namespace UnitTests.MatrixMetadataTests
             dimension.AdditionalProperties.Add(PxSyntaxConstants.NOTE_KEY, new MultilanguageStringProperty(new(note)));
 
             // Act
-            MultilanguageString? noteProperty = dimension.GetMultilanguageDimensionProperty(PxSyntaxConstants.NOTE_KEY);
+            MultilanguageString? noteProperty = dimension.GetMultilanguageDimensionProperty(PxSyntaxConstants.NOTE_KEY, "fi");
 
             // Assert
             Assert.That(noteProperty, Is.Not.Null);
@@ -95,7 +95,7 @@ namespace UnitTests.MatrixMetadataTests
             Dimension dimension = TestDataCubeBuilder.BuildTestDimension("foo", dimParams, ["fi", "en"]);
 
             // Act
-            MultilanguageString? noteProperty = dimension.GetMultilanguageDimensionProperty(PxSyntaxConstants.NOTE_KEY);
+            MultilanguageString? noteProperty = dimension.GetMultilanguageDimensionProperty(PxSyntaxConstants.NOTE_KEY, "fi");
 
             // Assert
             Assert.That(noteProperty, Is.Null);
@@ -111,7 +111,7 @@ namespace UnitTests.MatrixMetadataTests
             dimension.AdditionalProperties.Add(PxSyntaxConstants.META_ID_KEY, metaString);
 
             // Act
-            MultilanguageString? metaProperty = dimension.GetMultilanguageDimensionProperty(PxSyntaxConstants.META_ID_KEY);
+            MultilanguageString? metaProperty = dimension.GetMultilanguageDimensionProperty(PxSyntaxConstants.META_ID_KEY, "fi");
 
             // Assert
             Assert.That(metaProperty, Is.Not.Null);

--- a/UnitTests/PxWebInterfaceTests/ModelExtensionsTests.cs
+++ b/UnitTests/PxWebInterfaceTests/ModelExtensionsTests.cs
@@ -1,6 +1,5 @@
 ﻿using NUnit.Framework;
 using PxGraf.Datasource.ApiDatasource.SerializationModels;
-using PxGraf.Datasource.PxWebInterface.SerializationModels;
 using System.Text.Json;
 using UnitTests.PxWebInterfaceTests.Fixtures;
 

--- a/UnitTests/TestDataCubeBuilder.cs
+++ b/UnitTests/TestDataCubeBuilder.cs
@@ -128,7 +128,7 @@ namespace UnitTests
         {
             IReadOnlyMatrixMetadata meta = BuildTestMeta(dimParams, languages);
             int dataSize = meta.Dimensions.Count == 0 ? 0 : meta.Dimensions.Aggregate(1, (acc, var) => acc * var.Values.Count);
-            return new Matrix<DecimalDataValue>(meta, BuildTestData(dataSize, negativeData, missingData).ToArray());
+            return new Matrix<DecimalDataValue>(meta, [.. BuildTestData(dataSize, negativeData, missingData)]);
         }
 
         public static MatrixMetadata BuildTestMeta(List<DimensionParameters> varParams, string[]? languages = null)
@@ -214,7 +214,7 @@ namespace UnitTests
         public static ArchiveCube BuildTestArchiveCube(List<DimensionParameters> metaParams, string[]? languages = null, string version = "1.0", Dictionary<int, MultilanguageString>? dataNotes = null)
         {
             MatrixMetadata meta = BuildTestMeta(metaParams, languages);
-            List<DecimalDataValue> data = BuildTestData(meta.Dimensions.Aggregate(1, (acc, var) => acc * var.Values.Count)).ToList();
+            List<DecimalDataValue> data = [.. BuildTestData(meta.Dimensions.Aggregate(1, (acc, var) => acc * var.Values.Count))];
 
             return new ArchiveCube
             (

--- a/UnitTests/Utilities/JsonObjectComparer.cs
+++ b/UnitTests/Utilities/JsonObjectComparer.cs
@@ -37,7 +37,7 @@ namespace UnitTests.Utilities
                     newStr.Add(json[i]);
                 }
             }
-            return new(newStr.ToArray());
+            return new([.. newStr]);
         }
     }
 }

--- a/UnitTests/UtilityFunctionsTests/MetaPropertyExtensionsTests.cs
+++ b/UnitTests/UtilityFunctionsTests/MetaPropertyExtensionsTests.cs
@@ -1,0 +1,52 @@
+﻿using NUnit.Framework;
+using Px.Utils.Models.Metadata.MetaProperties;
+using PxGraf.Utility;
+using System;
+
+namespace UnitTests.UtilityFunctionsTests
+{
+    public class MetaPropertyExtensionsTests
+    {
+        [Test]
+        public void AsMultiLanguageProperty_WithMultilanguageStringProperty_ReturnsSameInstance()
+        {
+            // Arrange
+            string lang = "en";
+            MultilanguageStringProperty originalProperty = new(new(lang, "TestValue"));
+
+            // Act
+            MultilanguageStringProperty result = originalProperty.AsMultiLanguageProperty(lang);
+
+            // Assert
+            Assert.That(originalProperty, Is.SameAs(result));
+        }
+
+        [Test]
+        public void AsMultiLanguageProperty_WithStringProperty_ReturnsMultilanguageStringProperty()
+        {
+            // Arrange
+            string lang = "en";
+            StringProperty originalProperty = new("TestValue");
+
+            // Act
+            MultilanguageStringProperty result = originalProperty.AsMultiLanguageProperty(lang);
+
+            // Assert
+            Assert.That(result, Is.TypeOf<MultilanguageStringProperty>());
+            Assert.That(result.Value[lang], Is.EqualTo("TestValue"));
+        }
+
+        [Test]
+        public void AsMultiLanguageProperty_WithInvalidPropertyType_ThrowsArgumentException()
+        {
+            // Arrange
+            string lang = "en";
+            StringListProperty originalProperty = new(["foo", "bar", "föö", "bär"]);
+
+            // Act & Assert
+            ArgumentException exception = Assert.Throws<ArgumentException>(() => originalProperty.AsMultiLanguageProperty(lang));
+            Assert.That(exception.Message,
+                Is.EqualTo("Property of type Px.Utils.Models.Metadata.MetaProperties.StringListProperty can not be converted to multilanguage string property."));
+        }
+    }
+}


### PR DESCRIPTION
Fixed an issue where if the table only has one language some properties were processed as strings even though multilanguage strings were expected. These properies are required by PxGraf but are not part of the metadata structure returned by the Px.Utils library.

Propertied affected by this change:
- NOTE
- VALUENOTE
- SOURCE