### PR TITLE
Excessively large query + sorting order UI fix

### DIFF
--- a/PxGraf.Frontend/package.json
+++ b/PxGraf.Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxgraf",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/SortingSelector.test.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/SortingSelector.test.tsx
@@ -1,0 +1,93 @@
+import { render } from '@testing-library/react';
+import { ISortingOption } from "../../../types/editorContentsResponse";
+import { IVisualizationSettings } from "../../../types/visualizationSettings";
+import UiLanguageContext from '../../../contexts/uiLanguageContext';
+import { EditorContext } from '../../../contexts/editorContext';
+import React from 'react';
+import SortingSelector from './SortingSelector';
+import userEvent from '@testing-library/user-event';
+
+const visualizationSettings: IVisualizationSettings = {
+    sorting: "foo"
+};
+
+const sortingOptions: ISortingOption[] = [
+    {
+        code: "foo",
+        description: {
+            fi: "foo.fi",
+            sv: "foo.sv",
+            en: "foo.en"
+        }
+    },
+    {
+        code: "bar",
+        description: {
+            fi: "bar.fi",
+            sv: "bar.sv",
+            en: "bar.en"
+        }
+    }
+];
+
+const languageContext =
+{
+    language: 'fi',
+    setLanguage: jest.fn(),
+    languageTab: 'fi',
+    setLanguageTab: jest.fn(),
+    availableUiLanguages: ['fi', 'en', 'sv'],
+    uiContentLanguage: 'fi',
+    setUiContentLanguage: jest.fn()
+};
+
+const editorContext = {
+    cubeQuery: null,
+    setCubeQuery: jest.fn(),
+    query: null,
+    setQuery: jest.fn(),
+    saveDialogOpen: false,
+    setSaveDialogOpen: jest.fn(),
+    selectedVisualizationUserInput: null,
+    setSelectedVisualizationUserInput: jest.fn(),
+    visualizationSettingsUserInput: null,
+    setVisualizationSettingsUserInput: jest.fn(),
+    defaultSelectables: null,
+    setDefaultSelectables: jest.fn()
+};
+
+describe('rendering test', () => {
+    it('renders sorting selector correctly', () => {
+        const { asFragment } = render(
+            <UiLanguageContext.Provider value={languageContext}>
+                <EditorContext.Provider value={editorContext}>
+                    <SortingSelector visualizationSettings={visualizationSettings} sortingOptions={sortingOptions} />
+                </EditorContext.Provider>
+            </UiLanguageContext.Provider>
+        );
+
+        expect(asFragment()).toMatchSnapshot();
+    })
+})
+
+describe('functionality test', () => {
+    it('calls setVisualizationSettingsUserInput with the correct value when value is selected', async () => {
+        const user = userEvent.setup();
+        const mockSetVisualizationSettingsUserInput = jest.fn();
+        const { getByLabelText, getByText } = render(
+            <UiLanguageContext.Provider value={languageContext}>
+                <EditorContext.Provider value={{ ...editorContext, setVisualizationSettingsUserInput: mockSetVisualizationSettingsUserInput }}>
+                    <SortingSelector visualizationSettings={visualizationSettings} sortingOptions={sortingOptions} />
+                </EditorContext.Provider>
+            </UiLanguageContext.Provider>
+        );
+        const sortingSelector = getByLabelText('chartSettings.sort');
+        await user.click(sortingSelector);
+        const option = getByText('bar.fi');
+        await user.click(option);
+        expect(mockSetVisualizationSettingsUserInput).toHaveBeenCalledWith({
+            ...visualizationSettings,
+            sorting: 'bar'
+        });
+    });
+});

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/SortingSelector.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/SortingSelector.tsx
@@ -27,7 +27,10 @@ export const SortingSelector: React.FC<ISortingSelectorProps> = ({ sortingOption
                 id="sorting-selector"
                 label={t("chartSettings.sort")}
                 value={visualizationSettings.sorting}
-                onBlur={(event) => setVisualizationSettingsUserInput({ ...visualizationSettings, sorting: event.target.value })}
+                onChange={(event) => setVisualizationSettingsUserInput({
+                    ...visualizationSettings,
+                    sorting: event.target.value
+                })}
             >
                 {sortingOptions.map(v => { return <MenuItem key={"key" + v.code} value={v.code}>{v.description[uiContentLanguage]}</MenuItem> })}
             </Select>

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/__snapshots__/SortingSelector.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/__snapshots__/SortingSelector.test.tsx.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rendering test renders sorting selector correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
+  >
+    <label
+      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
+      data-shrink="true"
+      id="sorting-selector-label"
+    >
+      chartSettings.sort
+    </label>
+    <div
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-j5ihgt-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+    >
+      <div
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="sorting-selector-label sorting-selector"
+        class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-w76bbz-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+        id="sorting-selector"
+        role="combobox"
+        tabindex="0"
+      >
+        foo.fi
+      </div>
+      <input
+        aria-hidden="true"
+        aria-invalid="false"
+        class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+        tabindex="-1"
+        value="foo"
+      />
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-lohd6h-MuiSvgIcon-root-MuiSelect-icon"
+        data-testid="ArrowDropDownIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M7 10l5 5 5-5z"
+        />
+      </svg>
+      <fieldset
+        aria-hidden="true"
+        class="MuiOutlinedInput-notchedOutline css-1ll44ll-MuiOutlinedInput-notchedOutline"
+      >
+        <legend
+          class="css-w1u3ce"
+        >
+          <span>
+            chartSettings.sort
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/PxGraf/Controllers/CreationController.cs
+++ b/PxGraf/Controllers/CreationController.cs
@@ -24,7 +24,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using System;
 using PxGraf.Datasource.FileDatasource;
-using System.Drawing;
 
 namespace PxGraf.Controllers
 {

--- a/PxGraf/Controllers/CreationController.cs
+++ b/PxGraf/Controllers/CreationController.cs
@@ -209,11 +209,11 @@ namespace PxGraf.Controllers
             IReadOnlyMatrixMetadata filteredMeta = tableMeta.FilterDimensionValues(query);
             int includedValuesCount = filteredMeta.Dimensions.Select(x => x.Values.Count).Aggregate((a, x) => a * x);
 
-            if (includedValuesCount == 0)
+            if (includedValuesCount == 0 || includedValuesCount > maxQuerySize)
             {
                 return new EditorContentsResponse()
                 {
-                    Size = 0,
+                    Size = includedValuesCount,
                     MaximumSupportedSize = maxQuerySize,
                     SizeWarningLimit = Convert.ToInt32(maxQuerySize * 0.75),
                     HeaderText = new MultilanguageString(Configuration.Current.LanguageOptions.Available.Select(lang => new KeyValuePair<string, string>(lang, string.Empty))),

--- a/PxGraf/PxGraf.csproj
+++ b/PxGraf/PxGraf.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>PxGraf</AssemblyName>
     <UserSecretsId>5fefcbdc-e04e-4475-9927-aab412b027ff</UserSecretsId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>4.1.12</VersionPrefix>
+    <VersionPrefix>4.1.13</VersionPrefix>
 	<SpaRoot>..\PxGraf.Frontend</SpaRoot>
 	<Configurations>Debug;Release;Test</Configurations>
   </PropertyGroup>

--- a/UnitTests/ControllerTests/CreationControllerTests/GetEditorContentsTests.cs
+++ b/UnitTests/ControllerTests/CreationControllerTests/GetEditorContentsTests.cs
@@ -107,5 +107,38 @@ namespace UnitTests.ControllerTests.CreationControllerTests
             Assert.That(editorContent.Value, Is.Not.Null);
             Assert.That(editorContent.Value.Size.Equals(0), Is.True);
         }
+
+        [Test]
+        public async Task GetEditorContents_ExceedinglyLargeQuery_ReturnsWithNoValidVisualizations()
+        {
+            List<DimensionParameters> cubeParams =
+            [
+                new DimensionParameters(DimensionType.Content, 1),
+                new DimensionParameters(DimensionType.Time, 96),
+                new DimensionParameters(DimensionType.Other, 100),
+                new DimensionParameters(DimensionType.Other, 100),
+                new DimensionParameters(DimensionType.Other, 10) { Selectable = true},
+            ];
+
+            List<DimensionParameters> metaParams =
+            [
+                new DimensionParameters(DimensionType.Content, 5),
+                new DimensionParameters(DimensionType.Time, 192),
+                new DimensionParameters(DimensionType.Other, 128),
+                new DimensionParameters(DimensionType.Other, 128),
+                new DimensionParameters(DimensionType.Other, 16),
+            ];
+
+
+            CreationController testController = TestCreationControllerBuilder.BuildController(cubeParams, metaParams);
+            MatrixQuery cubeQuery = TestDataCubeBuilder.BuildTestCubeQuery(cubeParams);
+
+            ActionResult<EditorContentsResponse> editorContent = await testController.GetEditorContents(cubeQuery);
+
+            Assert.That(editorContent, Is.Not.Null);
+            Assert.That(editorContent.Value, Is.Not.Null);
+            Assert.That(editorContent.Value.Size.Equals(9600000), Is.True);
+            Assert.That(editorContent.Value.VisualizationOptions.Count, Is.EqualTo(0));
+        }
     }
 }


### PR DESCRIPTION
Returns 0 valid visualizations in editor contents if query size exceeds max query size defined in appsettings
Added test to cover such case under editor contents endpoint tests
Additional fix to the editor UI which wouldn't update sorting selection for horizontal bar charts after latest changes. Tests added to cover sorting selector rendering and functionality