### PR TITLE
Bugfix: Local database configuration

### DIFF
--- a/PxGraf/Controllers/CreationController.cs
+++ b/PxGraf/Controllers/CreationController.cs
@@ -34,7 +34,7 @@ namespace PxGraf.Controllers
     {
         private readonly ICachedDatasource _datasource = datasource;
         private readonly ILogger<CreationController> _logger = logger;
-        private readonly string[] databaseWhitelist = Configuration.Current.LocalFilesystemDatabaseConfig.DatabaseWhitelist;
+        private readonly string[] databaseWhitelist = Configuration.Current.DatabaseWhitelist;
 
         /// <summary>
         /// Returns a list of database items from the given level of the data base based on the dbPath.

--- a/PxGraf/Datasource/FileDatasource/LocalFilesystemDatabaseConfig.cs
+++ b/PxGraf/Datasource/FileDatasource/LocalFilesystemDatabaseConfig.cs
@@ -2,12 +2,10 @@
 
 namespace PxGraf.Datasource.FileDatasource
 {
-    public class LocalFilesystemDatabaseConfig(bool enabled, string databaseRootPath, Encoding encoding, string[] databaseWhitelist)
+    public class LocalFilesystemDatabaseConfig(bool enabled, string databaseRootPath, Encoding encoding)
     {
         public bool Enabled { get; } = enabled;
         public string DatabaseRootPath { get; } = databaseRootPath;
-
         public Encoding Encoding { get; } = encoding;
-        public string[] DatabaseWhitelist { get; } = databaseWhitelist;
     }
 }

--- a/PxGraf/Settings/Configuration.cs
+++ b/PxGraf/Settings/Configuration.cs
@@ -18,6 +18,7 @@ namespace PxGraf.Settings
         public CacheOptions CacheOptions { get; private set; }
         public CorsOptions CorsOptions { get; private set; }
         public LocalFilesystemDatabaseConfig LocalFilesystemDatabaseConfig { get; private set; }
+        public string[] DatabaseWhitelist { get; private set; }
 
         public static void Load(IConfiguration configuration)
         {
@@ -53,11 +54,13 @@ namespace PxGraf.Settings
                     AllowedOrigins = configuration.GetSection("Cors:AllowedOrigins").Get<string[]>(),
                 },
                 LocalFilesystemDatabaseConfig = new LocalFilesystemDatabaseConfig(
-                    configuration.GetSection("LocalFileSystemDatabaseConfig:Enabled").Get<bool>(),
-                    configuration["LocalFilesystemDatabaseConfig:DatabaseRootPath"],
-                    Encoding.GetEncoding(configuration["LocalFilesystemDatabaseConfig:Encoding"]),
-                    configuration.GetSection("LocalFilesystemDatabaseConfig:DatabaseWhitelist").Get<string[]>()
-                )
+                    configuration.GetSection("LocalFileSystemDatabaseConfig:Enabled").Get<bool?>() ?? false,
+                    configuration["LocalFilesystemDatabaseConfig:DatabaseRootPath"] ?? string.Empty,
+                    !string.IsNullOrEmpty(configuration["LocalFilesystemDatabaseConfig:Encoding"])
+                        ? Encoding.GetEncoding(configuration["LocalFilesystemDatabaseConfig:Encoding"])
+                        : Encoding.Default
+                ),
+                DatabaseWhitelist = configuration.GetSection("DatabaseWhitelist").Get<string[]>() ?? []
             };
 
             Current = newConfig;

--- a/UnitTests/Fixtures/TestInMemoryConfiguration.cs
+++ b/UnitTests/Fixtures/TestInMemoryConfiguration.cs
@@ -31,7 +31,7 @@ namespace UnitTests.Fixtures
                     { "Language:Available:1", "sv"},
                     { "Language:Available:2", "en"},
                     { "LocalFilesystemDatabaseConfig:Encoding", "latin1"},
-                    { "LocalFilesystemDatabaseConfig:DatabaseWhitelist:0", "StatFin" }
+                    { "DatabaseWhitelist:0", "StatFin" }
             };
         }
     }


### PR DESCRIPTION
Moves database whitelisting outside of local database configuration and allows empty lists.
If no local database configuration is provided, will return default values using pxweb api instead.