### PR TITLE
Refactor path normalization for storage

### DIFF
--- a/PxGraf/PxGraf.csproj
+++ b/PxGraf/PxGraf.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>PxGraf</AssemblyName>
     <UserSecretsId>5fefcbdc-e04e-4475-9927-aab412b027ff</UserSecretsId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>4.6.2</VersionPrefix>
+    <VersionPrefix>4.6.3</VersionPrefix>
 	<SpaRoot>..\PxGraf.Frontend</SpaRoot>
 	<Configurations>Debug;Release;Test</Configurations>
   </PropertyGroup>

--- a/PxGraf/Startup.cs
+++ b/PxGraf/Startup.cs
@@ -197,25 +197,19 @@ namespace PxGraf
                         blobConfig.ManagedIdentityClientId);
                     services.AddSingleton<ISqFileInterface>(provider => new SqFileInterface(
                         blobQueryProvider,
-                        blobQueryProvider,
-                        blobConfig.SavedQueryPath,
-                        blobConfig.ArchiveFilePath));
+                        blobQueryProvider));
                     break;
                 case LocalQueryStorageConfig localConfig:
                     LocalStorageProvider localQueryProvider = new();
                     services.AddSingleton<ISqFileInterface>(provider => new SqFileInterface(
                         localQueryProvider,
-                        localQueryProvider,
-                        localConfig.SavedQueryDirectory,
-                        localConfig.ArchiveFileDirectory));
+                        localQueryProvider));
                     break;
                 default:
                     LocalStorageProvider defaultQueryProvider = new();
                     services.AddSingleton<ISqFileInterface>(provider => new SqFileInterface(
                         defaultQueryProvider,
-                        defaultQueryProvider,
-                        Configuration.Current.SavedQueryDirectory ?? "",
-                        Configuration.Current.ArchiveFileDirectory ?? ""));
+                        defaultQueryProvider));
                     break;
             }
         }

--- a/PxGraf/Startup.cs
+++ b/PxGraf/Startup.cs
@@ -199,7 +199,7 @@ namespace PxGraf
                         blobQueryProvider,
                         blobQueryProvider));
                     break;
-                case LocalQueryStorageConfig localConfig:
+                case LocalQueryStorageConfig:
                     LocalStorageProvider localQueryProvider = new();
                     services.AddSingleton<ISqFileInterface>(provider => new SqFileInterface(
                         localQueryProvider,

--- a/PxGraf/Storage/BlobStorageProvider.cs
+++ b/PxGraf/Storage/BlobStorageProvider.cs
@@ -32,7 +32,7 @@ namespace PxGraf.Storage
         /// <inheritdoc/>
         public async Task<bool> FileExistsAsync(string filePath)
         {
-            string blobName = ConvertToAzurePath(filePath);
+            string blobName = PathNormalizer.NormalizeToAzurePath(filePath);
             BlobClient blobClient = containerClient.GetBlobClient(blobName);
             try
             {
@@ -47,7 +47,7 @@ namespace PxGraf.Storage
         /// <inheritdoc/>
         public async Task<string> ReadAllTextAsync(string filePath)
         {
-            string blobName = ConvertToAzurePath(filePath);
+            string blobName = PathNormalizer.NormalizeToAzurePath(filePath);
             BlobClient blobClient = containerClient.GetBlobClient(blobName);
             using Stream blobStream = await blobClient.OpenReadAsync();
 
@@ -72,7 +72,7 @@ namespace PxGraf.Storage
         /// <inheritdoc/>
         public async Task WriteAllTextAsync(string filePath, string content)
         {
-            string blobName = ConvertToAzurePath(filePath);
+            string blobName = PathNormalizer.NormalizeToAzurePath(filePath);
             BlobClient blobClient = containerClient.GetBlobClient(blobName);
             await blobClient.UploadAsync(new MemoryStream(Encoding.UTF8.GetBytes(content)), overwrite: true);
         }
@@ -80,7 +80,7 @@ namespace PxGraf.Storage
         /// <inheritdoc/>
         public async Task<Stream> OpenReadAsync(string filePath)
         {
-            string blobName = ConvertToAzurePath(filePath);
+            string blobName = PathNormalizer.NormalizeToAzurePath(filePath);
             BlobClient blobClient = containerClient.GetBlobClient(blobName);
             return await blobClient.OpenReadAsync();
         }
@@ -89,7 +89,7 @@ namespace PxGraf.Storage
         public async Task<IEnumerable<string>> EnumerateFilesAsync(string directoryPath, string fileExtension)
         {
             List<string> files = [];
-            string prefix = ConvertToAzurePath(directoryPath) ?? "";
+            string prefix = PathNormalizer.NormalizeToAzurePath(directoryPath) ?? "";
             if (!string.IsNullOrEmpty(prefix))
             {
                 prefix += "/";
@@ -116,7 +116,7 @@ namespace PxGraf.Storage
         public async Task<IEnumerable<string>> EnumerateDirectoriesAsync(string directoryPath)
         {
             HashSet<string> directories = [];
-            string prefix = ConvertToAzurePath(directoryPath) ?? "";
+            string prefix = PathNormalizer.NormalizeToAzurePath(directoryPath) ?? "";
             if (!string.IsNullOrEmpty(prefix))
             {
                 prefix += "/";
@@ -140,7 +140,7 @@ namespace PxGraf.Storage
         /// <inheritdoc/>
         public async Task<DateTime> GetLastWriteTimeAsync(string filePath)
         {
-            string blobName = ConvertToAzurePath(filePath);
+            string blobName = PathNormalizer.NormalizeToAzurePath(filePath);
             BlobClient blobClient = containerClient.GetBlobClient(blobName);
             BlobProperties properties = await blobClient.GetPropertiesAsync();
             return properties.LastModified.DateTime;
@@ -149,7 +149,7 @@ namespace PxGraf.Storage
         /// <inheritdoc/>
         public string GetDirectoryName(string directoryPath)
         {
-            string azurePath = ConvertToAzurePath(directoryPath);
+            string azurePath = PathNormalizer.NormalizeToAzurePath(directoryPath);
             int lastSlashIndex = azurePath.LastIndexOf('/');
             return lastSlashIndex >= 0 ? azurePath[(lastSlashIndex + 1)..] : azurePath;
         }
@@ -157,42 +157,31 @@ namespace PxGraf.Storage
         /// <inheritdoc/>
         public string GetFileName(string filePath)
         {
-            string azurePath = ConvertToAzurePath(filePath);
+            string azurePath = PathNormalizer.NormalizeToAzurePath(filePath);
             return Path.GetFileName(azurePath);
-        }
-
-        /// <inheritdoc/>
-        public string CombinePath(params string[] paths)
-        {
-            return string.Join("/", paths);
         }
 
         /// <inheritdoc/>
         public string BuildPath(string rootPath, string userPath)
         {
             // Convert both to Azure path format
-            string azureRootPath = ConvertToAzurePath(rootPath) ?? "";
-            string azureUserPath = ConvertToAzurePath(userPath) ?? "";
-
-            // Remove any leading slashes from user path to avoid double slashes
-            azureUserPath = azureUserPath.TrimStart('/');
+            string azureRootPath = PathNormalizer.NormalizeToAzurePath(rootPath) ?? "";
+            string azureUserPath = PathNormalizer.NormalizeToAzurePath(userPath) ?? "";
 
             // Combine paths using shared utility
-            string combinedPath = PathNormalizer.CombinePaths(azureRootPath, azureUserPath);
+            string combinedPath = PathNormalizer.CombineAndNormalizeAzurePaths(azureRootPath, azureUserPath);
 
             // Security check: ensure the combined path doesn't try to escape the root using ".."
-            int rootDepth = PathNormalizer.GetPathDepth(azureRootPath);
-            PathNormalizer.ValidatePathSecurity(combinedPath, rootDepth);
+            PathNormalizer.ValidatePathSecurity(combinedPath, azureRootPath);
 
-            // Normalize the path by removing "." and resolving ".."
-            return PathNormalizer.NormalizePath(combinedPath);
+            return combinedPath;
         }
 
         /// <inheritdoc/>
         public string GetRelativePath(string basePath, string targetPath)
         {
-            string azureBasePath = ConvertToAzurePath(basePath);
-            string azureTargetPath = ConvertToAzurePath(targetPath);
+            string azureBasePath = PathNormalizer.NormalizeToAzurePath(basePath);
+            string azureTargetPath = PathNormalizer.NormalizeToAzurePath(targetPath);
 
             // Handle empty base path case
             if (string.IsNullOrEmpty(azureBasePath))
@@ -220,14 +209,6 @@ namespace PxGraf.Storage
             return azureTargetPath;
         }
 
-        /// <summary>
-        /// Converts Windows-style paths to Azure blob paths.
-        /// </summary>
-        /// <param name="path">Path to convert.</param>
-        /// <returns>Azure blob path.</returns>
-        private static string ConvertToAzurePath(string path)
-        {
-            return path?.Replace('\\', '/') ?? string.Empty;
-        }
+        public string CombinePath(params string[] paths) => PathNormalizer.CombineAndNormalizeAzurePaths(paths);
     }
 }

--- a/PxGraf/Storage/PathNormalizer.cs
+++ b/PxGraf/Storage/PathNormalizer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace PxGraf.Storage
 {
@@ -29,66 +30,60 @@ namespace PxGraf.Storage
         }
 
         /// <summary>
-        /// Combines two path segments with a forward slash, handling edge cases.
+        /// Combines path segments with a forward slash, handling edge cases.
         /// </summary>
-        /// <param name="rootPath">The root path segment.</param>
-        /// <param name="userPath">The user-provided path segment.</param>
-        /// <returns>Combined path string.</returns>
-        public static string CombinePaths(string rootPath, string userPath)
+        public static string CombineAndNormalizeAzurePaths(params string[] paths)
         {
-            if (string.IsNullOrEmpty(rootPath))
+            if (paths == null || paths.Length == 0)
             {
-                return userPath;
+                return string.Empty;
             }
 
-            if (string.IsNullOrEmpty(userPath))
-            {
-                return rootPath;
-            }
-
-            return $"{rootPath.TrimEnd('/')}/{userPath}";
+            string[] nonEmptyPaths = [.. paths.Where(p => !string.IsNullOrEmpty(p)).Select(NormalizeToAzurePath)];
+            return string.Join("/", nonEmptyPaths);
         }
 
         /// <summary>
         /// Validates that a path does not escape the root path boundary using ".." segments.
         /// </summary>
         /// <param name="combinedPath">The combined path to validate.</param>
-        /// <param name="rootDepth">The depth of the root path (number of segments).</param>
+        /// <param name="rootPath">The root path to compare against.</param>
         /// <exception cref="UnauthorizedAccessException">Thrown if the path attempts to escape the root boundary.</exception>
-        public static void ValidatePathSecurity(string combinedPath, int rootDepth)
+        public static void ValidatePathSecurity(string combinedPath, string rootPath)
         {
-            string[] segments = combinedPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
-            int depth = 0;
+            string normalizedCombinedPath = NormalizeToAzurePath(combinedPath);
+            string normalizedRootPath = NormalizeToAzurePath(rootPath);
 
-            foreach (string segment in segments)
+            if (string.IsNullOrEmpty(normalizedRootPath))
             {
-                if (segment == "..")
-                {
-                    depth--;
-                    if (depth < rootDepth)
-                    {
-                        throw new UnauthorizedAccessException("Access to the path is denied.");
-                    }
-                }
-                else if (segment != ".")
-                {
-                    depth++;
-                }
+                return;
+            }
+
+            if (normalizedCombinedPath.Equals(normalizedRootPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (!normalizedCombinedPath.StartsWith(normalizedRootPath + "/", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new UnauthorizedAccessException("Access to the path is denied.");
             }
         }
 
         /// <summary>
         /// Normalizes a path by removing "." segments and resolving ".." segments.
+        /// Also converts backslashes to forward slashes and removes duplicate slashes.
         /// </summary>
         /// <param name="path">The path to normalize.</param>
         /// <returns>Normalized path with resolved relative segments.</returns>
-        public static string NormalizePath(string path)
+        public static string NormalizeToAzurePath(string path)
         {
             if (string.IsNullOrEmpty(path))
             {
                 return string.Empty;
             }
 
+            path = path.Replace('\\', '/');
             string[] segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
             List<string> normalizedSegments = [];
 
@@ -108,21 +103,6 @@ namespace PxGraf.Storage
             }
 
             return string.Join("/", normalizedSegments);
-        }
-
-        /// <summary>
-        /// Calculates the depth of a path (number of segments).
-        /// </summary>
-        /// <param name="path">The path to analyze.</param>
-        /// <returns>Number of path segments, or 0 if path is empty.</returns>
-        public static int GetPathDepth(string path)
-        {
-            if (string.IsNullOrEmpty(path))
-            {
-                return 0;
-            }
-
-            return path.Split('/', StringSplitOptions.RemoveEmptyEntries).Length;
         }
     }
 }

--- a/PxGraf/Storage/PathNormalizer.cs
+++ b/PxGraf/Storage/PathNormalizer.cs
@@ -39,7 +39,10 @@ namespace PxGraf.Storage
                 return string.Empty;
             }
 
-            string[] nonEmptyPaths = [.. paths.Where(p => !string.IsNullOrEmpty(p)).Select(NormalizeToAzurePath)];
+            string[] nonEmptyPaths = [.. paths
+                .Where(p => !string.IsNullOrEmpty(p))
+                .Select(NormalizeToAzurePath)
+                .Where(p => !string.IsNullOrEmpty(p))];
             return string.Join("/", nonEmptyPaths);
         }
 

--- a/PxGraf/Utility/SqFileInterface.cs
+++ b/PxGraf/Utility/SqFileInterface.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using PxGraf.Models.SavedQueries;
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Threading.Tasks;
 using PxGraf.Settings;
 using PxGraf.Storage;
@@ -17,16 +16,12 @@ namespace PxGraf.Utility
     /// </remarks>
     /// <param name="savedQueryStorage">Storage provider for saved query files.</param>
     /// <param name="archiveStorage">Storage provider for archive files.</param>
-    /// <param name="savedQueryPath">Base path for saved query files.</param>
-    /// <param name="archivePath">Base path for archive files.</param>
     [ExcludeFromCodeCoverage] // Not worth it to build abstraction over storage IO in order to test such simple functionality
-    public class SqFileInterface(IStorageProvider savedQueryStorage, IStorageProvider archiveStorage, string savedQueryPath = "", string archivePath = "") : ISqFileInterface
+    public class SqFileInterface(IStorageProvider savedQueryStorage, IStorageProvider archiveStorage) : ISqFileInterface
     {
         private readonly static LockByKey lockScope = new(StringComparer.OrdinalIgnoreCase);
         private readonly IStorageProvider savedQueryStorage = savedQueryStorage ?? throw new ArgumentNullException(nameof(savedQueryStorage));
         private readonly IStorageProvider archiveStorage = archiveStorage ?? throw new ArgumentNullException(nameof(archiveStorage));
-        private readonly string savedQueryPath = savedQueryPath ?? "";
-        private readonly string archivePath = archivePath ?? "";
 
         /// <summary>
         /// Returns true if a saved query file with the given sq id exists within the specified saved query file location.
@@ -35,7 +30,7 @@ namespace PxGraf.Utility
         {
             if (InputValidation.ValidateSqIdString(id))
             {
-                string filePath = savedQueryStorage.CombinePath(savedQueryPath, savedQueryDirectory, id + ".sq");
+                string filePath = savedQueryStorage.CombinePath(savedQueryDirectory, id + ".sq");
                 return savedQueryStorage.FileExistsAsync(filePath).GetAwaiter().GetResult();
             }
             else
@@ -51,7 +46,7 @@ namespace PxGraf.Utility
         {
             if (InputValidation.ValidateSqIdString(id))
             {
-                string filePath = archiveStorage.CombinePath(archivePath, archiveDirectory, id + ".sqa");
+                string filePath = archiveStorage.CombinePath(archiveDirectory, id + ".sqa");
                 return archiveStorage.FileExistsAsync(filePath).GetAwaiter().GetResult();
             }
             else
@@ -65,7 +60,7 @@ namespace PxGraf.Utility
         /// </summary>
         public async Task<SavedQuery> ReadSavedQueryFromFile(string id, string savedQueryDirectory)
         {
-            string filePath = savedQueryStorage.CombinePath(savedQueryPath, savedQueryDirectory, id + ".sq");
+            string filePath = savedQueryStorage.CombinePath(savedQueryDirectory, id + ".sq");
             return await lockScope.RunLocked(
                 filePath,
                 () => ReadJsonObjectFromFileImpl<SavedQuery>(savedQueryStorage, filePath)
@@ -77,7 +72,7 @@ namespace PxGraf.Utility
         /// </summary>
         public async Task<ArchiveCube> ReadArchiveCubeFromFile(string id, string archiveDirectory)
         {
-            string filePath = archiveStorage.CombinePath(archivePath, archiveDirectory, id + ".sqa");
+            string filePath = archiveStorage.CombinePath(archiveDirectory, id + ".sqa");
             return await lockScope.RunLocked(
                 filePath,
                 () => ReadJsonObjectFromFileImpl<ArchiveCube>(archiveStorage, filePath)
@@ -113,7 +108,7 @@ namespace PxGraf.Utility
 
         private void SerializeToFileImpl(string fileName, string filePath, object input)
         {
-            string fullPath = savedQueryStorage.CombinePath(savedQueryPath, filePath, fileName);
+            string fullPath = savedQueryStorage.CombinePath(filePath, fileName);
             string json = JsonSerializer.Serialize(input, GlobalJsonConverterOptions.Default);
             savedQueryStorage.WriteAllTextAsync(fullPath, json).GetAwaiter().GetResult();
         }

--- a/UnitTests/Storage/PathNormalizerTests.cs
+++ b/UnitTests/Storage/PathNormalizerTests.cs
@@ -172,6 +172,56 @@ namespace UnitTests.Storage
             Assert.That(result, Is.EqualTo("root/path/user/path"));
         }
 
+        [Test]
+        public void CombineAndNormalizeAzurePaths_WithDotSegment_FiltersOutNormalizedEmptySegment()
+        {
+            // Act
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths("root", ".");
+
+            // Assert
+            Assert.That(result, Is.EqualTo("root"));
+        }
+
+        [Test]
+        public void CombineAndNormalizeAzurePaths_WithDotSlashSegment_FiltersOutNormalizedEmptySegment()
+        {
+            // Act
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths("root", "./");
+
+            // Assert
+            Assert.That(result, Is.EqualTo("root"));
+        }
+
+        [Test]
+        public void CombineAndNormalizeAzurePaths_WithSelfCancellingSegment_FiltersOutNormalizedEmptySegment()
+        {
+            // Act
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths("root", "a/..");
+
+            // Assert
+            Assert.That(result, Is.EqualTo("root"));
+        }
+
+        [Test]
+        public void CombineAndNormalizeAzurePaths_WithMultipleNormalizedEmptySegments_FiltersAllOut()
+        {
+            // Act
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths(".", "root", "a/..", "leaf");
+
+            // Assert
+            Assert.That(result, Is.EqualTo("root/leaf"));
+        }
+
+        [Test]
+        public void CombineAndNormalizeAzurePaths_AllSegmentsNormalizeToEmpty_ReturnsEmpty()
+        {
+            // Act
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths(".", "a/..", "./");
+
+            // Assert
+            Assert.That(result, Is.EqualTo(string.Empty));
+        }
+
         #endregion
 
         #region ValidatePathSecurity Tests

--- a/UnitTests/Storage/PathNormalizerTests.cs
+++ b/UnitTests/Storage/PathNormalizerTests.cs
@@ -70,130 +70,106 @@ namespace UnitTests.Storage
 
         #endregion
 
-        #region CombinePaths Tests
+        #region CombineAndNormalizeAzurePaths Tests
 
         [Test]
-        public void CombinePaths_BothEmpty_ReturnsEmpty()
+        public void CombineAndNormalizeAzurePaths_WithNull_ReturnsEmpty()
         {
             // Act
-            string result = PathNormalizer.CombinePaths(string.Empty, string.Empty);
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths(null);
 
             // Assert
             Assert.That(result, Is.EqualTo(string.Empty));
         }
 
         [Test]
-        public void CombinePaths_RootEmpty_ReturnsUserPath()
+        public void CombineAndNormalizeAzurePaths_WithNoArguments_ReturnsEmpty()
         {
             // Act
-            string result = PathNormalizer.CombinePaths(string.Empty, "user/path");
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void CombineAndNormalizeAzurePaths_BothEmpty_ReturnsEmpty()
+        {
+            // Act
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths(string.Empty, string.Empty);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void CombineAndNormalizeAzurePaths_RootEmpty_ReturnsUserPath()
+        {
+            // Act
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths(string.Empty, "user/path");
 
             // Assert
             Assert.That(result, Is.EqualTo("user/path"));
         }
 
         [Test]
-        public void CombinePaths_UserPathEmpty_ReturnsRootPath()
+        public void CombineAndNormalizeAzurePaths_UserPathEmpty_ReturnsRootPath()
         {
             // Act
-            string result = PathNormalizer.CombinePaths("root/path", string.Empty);
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths("root/path", string.Empty);
 
             // Assert
             Assert.That(result, Is.EqualTo("root/path"));
         }
 
         [Test]
-        public void CombinePaths_BothProvided_CombinesWithSlash()
+        public void CombineAndNormalizeAzurePaths_BothProvided_CombinesWithSlash()
         {
             // Act
-            string result = PathNormalizer.CombinePaths("root/path", "user/path");
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths("root/path", "user/path");
 
             // Assert
             Assert.That(result, Is.EqualTo("root/path/user/path"));
         }
 
         [Test]
-        public void CombinePaths_RootWithTrailingSlash_RemovesExtraSlash()
+        public void CombineAndNormalizeAzurePaths_RootWithTrailingSlash_RemovesExtraSlash()
         {
             // Act
-            string result = PathNormalizer.CombinePaths("root/path/", "user/path");
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths("root/path/", "user/path");
 
             // Assert
             Assert.That(result, Is.EqualTo("root/path/user/path"));
         }
 
         [Test]
-        public void CombinePaths_MultipleTrailingSlashes_NormalizesCorrectly()
+        public void CombineAndNormalizeAzurePaths_MultipleTrailingSlashes_NormalizesCorrectly()
         {
             // Act
-            string result = PathNormalizer.CombinePaths("root/path///", "user/path");
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths("root/path///", "user/path");
 
             // Assert
             Assert.That(result, Is.EqualTo("root/path/user/path"));
         }
 
-        #endregion
-
-        #region GetPathDepth Tests
-
         [Test]
-        public void GetPathDepth_WithNull_ReturnsZero()
+        public void CombineAndNormalizeAzurePaths_MoreThanTwoSegments_CombinesAll()
         {
             // Act
-            int result = PathNormalizer.GetPathDepth(null);
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths("root", "middle", "leaf");
 
             // Assert
-            Assert.That(result, Is.EqualTo(0));
+            Assert.That(result, Is.EqualTo("root/middle/leaf"));
         }
 
         [Test]
-        public void GetPathDepth_WithEmptyString_ReturnsZero()
+        public void CombineAndNormalizeAzurePaths_WithBackslashes_NormalizesToForwardSlashes()
         {
             // Act
-            int result = PathNormalizer.GetPathDepth(string.Empty);
+            string result = PathNormalizer.CombineAndNormalizeAzurePaths("root\\path", "user\\path");
 
             // Assert
-            Assert.That(result, Is.EqualTo(0));
-        }
-
-        [Test]
-        public void GetPathDepth_WithSingleSegment_ReturnsOne()
-        {
-            // Act
-            int result = PathNormalizer.GetPathDepth("folder");
-
-            // Assert
-            Assert.That(result, Is.EqualTo(1));
-        }
-
-        [Test]
-        public void GetPathDepth_WithTwoSegments_ReturnsTwo()
-        {
-            // Act
-            int result = PathNormalizer.GetPathDepth("folder/subfolder");
-
-            // Assert
-            Assert.That(result, Is.EqualTo(2));
-        }
-
-        [Test]
-        public void GetPathDepth_WithThreeSegments_ReturnsThree()
-        {
-            // Act
-            int result = PathNormalizer.GetPathDepth("root/folder/subfolder");
-
-            // Assert
-            Assert.That(result, Is.EqualTo(3));
-        }
-
-        [Test]
-        public void GetPathDepth_WithTrailingSlash_IgnoresEmptySegment()
-        {
-            // Act
-            int result = PathNormalizer.GetPathDepth("root/folder/");
-
-            // Assert
-            Assert.That(result, Is.EqualTo(2));
+            Assert.That(result, Is.EqualTo("root/path/user/path"));
         }
 
         #endregion
@@ -204,34 +180,34 @@ namespace UnitTests.Storage
         public void ValidatePathSecurity_WithValidPath_DoesNotThrow()
         {
             // Arrange
-            string path = "root/folder/subfolder";
-            int rootDepth = 1;
+            string combinedPath = "root/folder/subfolder";
+            string rootPath = "root";
 
             // Act & Assert
-            Assert.DoesNotThrow(() => PathNormalizer.ValidatePathSecurity(path, rootDepth));
+            Assert.DoesNotThrow(() => PathNormalizer.ValidatePathSecurity(combinedPath, rootPath));
         }
 
         [Test]
         public void ValidatePathSecurity_WithDotDotWithinBounds_DoesNotThrow()
         {
             // Arrange
-            string path = "root/folder/../other";
-            int rootDepth = 1;
+            string combinedPath = "root/folder/../other";
+            string rootPath = "root";
 
             // Act & Assert
-            Assert.DoesNotThrow(() => PathNormalizer.ValidatePathSecurity(path, rootDepth));
+            Assert.DoesNotThrow(() => PathNormalizer.ValidatePathSecurity(combinedPath, rootPath));
         }
 
         [Test]
         public void ValidatePathSecurity_WithDotDotEscapingRoot_ThrowsUnauthorizedAccessException()
         {
             // Arrange
-            string path = "root/../..";
-            int rootDepth = 1;
+            string combinedPath = "root/../..";
+            string rootPath = "root";
 
             // Act & Assert
             UnauthorizedAccessException exception = Assert.Throws<UnauthorizedAccessException>(
-                () => PathNormalizer.ValidatePathSecurity(path, rootDepth)
+                () => PathNormalizer.ValidatePathSecurity(combinedPath, rootPath)
             );
             Assert.That(exception.Message, Is.EqualTo("Access to the path is denied."));
         }
@@ -240,34 +216,93 @@ namespace UnitTests.Storage
         public void ValidatePathSecurity_WithDotSegments_DoesNotAffectValidation()
         {
             // Arrange
-            string path = "root/./folder/./subfolder";
-            int rootDepth = 1;
+            string combinedPath = "root/./folder/./subfolder";
+            string rootPath = "root";
 
             // Act & Assert
-            Assert.DoesNotThrow(() => PathNormalizer.ValidatePathSecurity(path, rootDepth));
+            Assert.DoesNotThrow(() => PathNormalizer.ValidatePathSecurity(combinedPath, rootPath));
         }
 
         [Test]
-        public void ValidatePathSecurity_WithZeroRootDepth_AllowsAnyPath()
+        public void ValidatePathSecurity_WithEmptyRootPath_AllowsAnyPath()
         {
             // Arrange
-            string path = "folder/subfolder";
-            int rootDepth = 0;
+            string combinedPath = "folder/subfolder";
+            string rootPath = "";
 
             // Act & Assert
-            Assert.DoesNotThrow(() => PathNormalizer.ValidatePathSecurity(path, rootDepth));
+            Assert.DoesNotThrow(() => PathNormalizer.ValidatePathSecurity(combinedPath, rootPath));
         }
 
         [Test]
         public void ValidatePathSecurity_WithMultipleDotDotsEscaping_ThrowsUnauthorizedAccessException()
         {
             // Arrange
-            string path = "root/folder/../../..";
-            int rootDepth = 1;
+            string combinedPath = "root/folder/../../..";
+            string rootPath = "root";
 
             // Act & Assert
             Assert.Throws<UnauthorizedAccessException>(
-                () => PathNormalizer.ValidatePathSecurity(path, rootDepth)
+                () => PathNormalizer.ValidatePathSecurity(combinedPath, rootPath)
+            );
+        }
+
+        [Test]
+        public void ValidatePathSecurity_CaseInsensitive_DoesNotThrow()
+        {
+            // Arrange
+            string combinedPath = "Root/Folder/SubFolder";
+            string rootPath = "root";
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => PathNormalizer.ValidatePathSecurity(combinedPath, rootPath));
+        }
+
+        [Test]
+        public void ValidatePathSecurity_CombinedPathEqualsRoot_DoesNotThrow()
+        {
+            // Arrange
+            string combinedPath = "root";
+            string rootPath = "root";
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => PathNormalizer.ValidatePathSecurity(combinedPath, rootPath));
+        }
+
+        [Test]
+        public void ValidatePathSecurity_WithBackslashes_NormalizesBeforeValidation()
+        {
+            // Arrange
+            string combinedPath = "root\\folder\\subfolder";
+            string rootPath = "root";
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => PathNormalizer.ValidatePathSecurity(combinedPath, rootPath));
+        }
+
+        [Test]
+        public void ValidatePathSecurity_CompletelyDifferentPath_ThrowsUnauthorizedAccessException()
+        {
+            // Arrange
+            string combinedPath = "other/folder";
+            string rootPath = "root";
+
+            // Act & Assert
+            Assert.Throws<UnauthorizedAccessException>(
+                () => PathNormalizer.ValidatePathSecurity(combinedPath, rootPath)
+            );
+        }
+
+        [Test]
+        public void ValidatePathSecurity_PrefixCollision_ThrowsUnauthorizedAccessException()
+        {
+            // Arrange - "rootother" starts with "root" but is not under the "root" directory
+            string combinedPath = "rootother/file";
+            string rootPath = "root";
+
+            // Act & Assert
+            Assert.Throws<UnauthorizedAccessException>(
+                () => PathNormalizer.ValidatePathSecurity(combinedPath, rootPath)
             );
         }
 
@@ -279,7 +314,7 @@ namespace UnitTests.Storage
         public void NormalizePath_WithNull_ReturnsEmptyString()
         {
             // Act
-            string result = PathNormalizer.NormalizePath(null);
+            string result = PathNormalizer.NormalizeToAzurePath(null);
 
             // Assert
             Assert.That(result, Is.EqualTo(string.Empty));
@@ -289,7 +324,7 @@ namespace UnitTests.Storage
         public void NormalizePath_WithEmptyString_ReturnsEmptyString()
         {
             // Act
-            string result = PathNormalizer.NormalizePath(string.Empty);
+            string result = PathNormalizer.NormalizeToAzurePath(string.Empty);
 
             // Assert
             Assert.That(result, Is.EqualTo(string.Empty));
@@ -299,7 +334,7 @@ namespace UnitTests.Storage
         public void NormalizePath_WithSimplePath_ReturnsSame()
         {
             // Act
-            string result = PathNormalizer.NormalizePath("root/folder/subfolder");
+            string result = PathNormalizer.NormalizeToAzurePath("root/folder/subfolder");
 
             // Assert
             Assert.That(result, Is.EqualTo("root/folder/subfolder"));
@@ -309,7 +344,7 @@ namespace UnitTests.Storage
         public void NormalizePath_WithDotSegments_RemovesDots()
         {
             // Act
-            string result = PathNormalizer.NormalizePath("root/./folder/./subfolder");
+            string result = PathNormalizer.NormalizeToAzurePath("root/./folder/./subfolder");
 
             // Assert
             Assert.That(result, Is.EqualTo("root/folder/subfolder"));
@@ -319,7 +354,7 @@ namespace UnitTests.Storage
         public void NormalizePath_WithDotDotSegments_ResolvesProperly()
         {
             // Act
-            string result = PathNormalizer.NormalizePath("root/folder/../subfolder");
+            string result = PathNormalizer.NormalizeToAzurePath("root/folder/../subfolder");
 
             // Assert
             Assert.That(result, Is.EqualTo("root/subfolder"));
@@ -329,7 +364,7 @@ namespace UnitTests.Storage
         public void NormalizePath_WithMultipleDotDots_ResolvesAll()
         {
             // Act
-            string result = PathNormalizer.NormalizePath("root/a/b/c/../../d");
+            string result = PathNormalizer.NormalizeToAzurePath("root/a/b/c/../../d");
 
             // Assert
             Assert.That(result, Is.EqualTo("root/a/d"));
@@ -339,7 +374,7 @@ namespace UnitTests.Storage
         public void NormalizePath_WithDotDotAtStart_IgnoresWhenNothingToGoUp()
         {
             // Act
-            string result = PathNormalizer.NormalizePath("../folder");
+            string result = PathNormalizer.NormalizeToAzurePath("../folder");
 
             // Assert
             Assert.That(result, Is.EqualTo("folder"));
@@ -349,7 +384,7 @@ namespace UnitTests.Storage
         public void NormalizePath_WithMixedDotAndDotDot_NormalizesCorrectly()
         {
             // Act
-            string result = PathNormalizer.NormalizePath("root/./folder/../other/./final");
+            string result = PathNormalizer.NormalizeToAzurePath("root/./folder/../other/./final");
 
             // Assert
             Assert.That(result, Is.EqualTo("root/other/final"));
@@ -359,7 +394,7 @@ namespace UnitTests.Storage
         public void NormalizePath_WithTrailingSlash_RemovesIt()
         {
             // Act
-            string result = PathNormalizer.NormalizePath("root/folder/");
+            string result = PathNormalizer.NormalizeToAzurePath("root/folder/");
 
             // Assert
             Assert.That(result, Is.EqualTo("root/folder"));
@@ -369,10 +404,40 @@ namespace UnitTests.Storage
         public void NormalizePath_WithLeadingSlash_RemovesIt()
         {
             // Act
-            string result = PathNormalizer.NormalizePath("/root/folder");
+            string result = PathNormalizer.NormalizeToAzurePath("/root/folder");
 
             // Assert
             Assert.That(result, Is.EqualTo("root/folder"));
+        }
+
+        [Test]
+        public void NormalizePath_WithBackslashes_ConvertedToForwardSlashes()
+        {
+            // Act
+            string result = PathNormalizer.NormalizeToAzurePath("root\\folder\\subfolder");
+
+            // Assert
+            Assert.That(result, Is.EqualTo("root/folder/subfolder"));
+        }
+
+        [Test]
+        public void NormalizePath_AllSegmentsCollapse_ReturnsEmpty()
+        {
+            // Act
+            string result = PathNormalizer.NormalizeToAzurePath("a/b/../../");
+
+            // Assert
+            Assert.That(result, Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void NormalizePath_WithDuplicateSlashes_RemovesThem()
+        {
+            // Act
+            string result = PathNormalizer.NormalizeToAzurePath("root//folder///subfolder");
+
+            // Assert
+            Assert.That(result, Is.EqualTo("root/folder/subfolder"));
         }
 
         #endregion
@@ -387,8 +452,8 @@ namespace UnitTests.Storage
             string userPath = "./folder/../other";
 
             // Act
-            string combined = PathNormalizer.CombinePaths(rootPath, userPath);
-            string normalized = PathNormalizer.NormalizePath(combined);
+            string combined = PathNormalizer.CombineAndNormalizeAzurePaths(rootPath, userPath);
+            string normalized = PathNormalizer.NormalizeToAzurePath(combined);
 
             // Assert
             Assert.That(normalized, Is.EqualTo("root/base/other"));
@@ -398,12 +463,12 @@ namespace UnitTests.Storage
         public void IntegrationTest_SecurityValidationAndNormalization_WorksTogether()
         {
             // Arrange
-            string path = "root/folder/./subfolder";
-            int rootDepth = 1;
+            string combinedPath = "root/folder/./subfolder";
+            string rootPath = "root";
 
             // Act & Assert
-            Assert.DoesNotThrow(() => PathNormalizer.ValidatePathSecurity(path, rootDepth));
-            string normalized = PathNormalizer.NormalizePath(path);
+            Assert.DoesNotThrow(() => PathNormalizer.ValidatePathSecurity(combinedPath, rootPath));
+            string normalized = PathNormalizer.NormalizeToAzurePath(combinedPath);
             Assert.That(normalized, Is.EqualTo("root/folder/subfolder"));
         }
 


### PR DESCRIPTION
Centralize path normalization and combination logic using PathNormalizer. Replace depth-based security checks with strict root prefix validation to prevent path traversal and prefix collisions. Remove redundant base path parameters from SqFileInterface. Update BlobStorageProvider to use new normalization utilities. Expand and update unit tests for edge cases and security.