### PR TITLE
[Fix] CI test script force exit fix

### DIFF
--- a/PxGraf.Frontend/package.json
+++ b/PxGraf.Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxgraf",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -25,7 +25,7 @@
     "build": "tsc && vite build",
     "serve": "vite preview",
     "test": "jest -c jest.config.ts",
-    "test:ci": "npm run test -- --coverage --ci --testResultsProcessor=\"jest-sonar-reporter\" --reporters=default --reporters=jest-junit --watchAll=false"
+    "test:ci": "npm run test -- --coverage --ci --testResultsProcessor=\"jest-sonar-reporter\" --reporters=default --reporters=jest-junit --watchAll=false --forceExit"
   },
   "jestSonar": {
     "reportPath": "reports",


### PR DESCRIPTION
Adds --forceExit argument to test:ci script. This works around commonly known open MESSAGEPORT handle issue with the current Jest/React/React Testing Library versions