### PR TITLE
[Refactor] Refactor tests to remove unnecessary i18next mocks and improve assertions

### DIFF
--- a/PxGraf.Frontend/jest.setup.ts
+++ b/PxGraf.Frontend/jest.setup.ts
@@ -1,33 +1,63 @@
-import { TextEncoder, TextDecoder } from 'util';
-import { ReadableStream, TransformStream, WritableStream } from 'stream/web';
-import { MessageChannel, MessagePort } from 'worker_threads';
+import { TextEncoder, TextDecoder } from 'node:util';
+import { ReadableStream, TransformStream, WritableStream } from 'node:stream/web';
+import { MessageChannel, MessagePort } from 'node:worker_threads';
+import { serialize, deserialize } from 'node:v8';
 
-global.TextEncoder = TextEncoder as typeof global.TextEncoder;
-global.TextDecoder = TextDecoder as typeof global.TextDecoder;
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder;
+globalThis.structuredClone ??= <T>(val: T): T => deserialize(serialize(val));
 
 // jsdom v28+ depends on undici which expects web stream APIs in the global scope
-if (typeof globalThis.ReadableStream === 'undefined') {
-    globalThis.ReadableStream = ReadableStream as typeof globalThis.ReadableStream;
-}
-if (typeof globalThis.WritableStream === 'undefined') {
-    globalThis.WritableStream = WritableStream as typeof globalThis.WritableStream;
-}
-if (typeof globalThis.TransformStream === 'undefined') {
-    globalThis.TransformStream = TransformStream as typeof globalThis.TransformStream;
-}
-if (typeof globalThis.MessageChannel === 'undefined') {
-    globalThis.MessageChannel = MessageChannel as typeof globalThis.MessageChannel;
-}
-if (typeof globalThis.MessagePort === 'undefined') {
-    globalThis.MessagePort = MessagePort as typeof globalThis.MessagePort;
-}
+globalThis.ReadableStream ??= ReadableStream as typeof globalThis.ReadableStream;
+globalThis.WritableStream ??= WritableStream as typeof globalThis.WritableStream;
+globalThis.TransformStream ??= TransformStream as typeof globalThis.TransformStream;
+// Polyfill MessageChannel/MessagePort for jsdom, with auto-unref on ports
+// to prevent React scheduler's internal MessageChannel from keeping the Jest worker alive.
+// Setting onmessage implicitly calls ref(), so we patch the setter to re-unref.
+if (globalThis.MessageChannel === undefined) {
+    const patchPort = (port: MessagePort) => {
+        const originalDescriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(port), 'onmessage');
+        if (originalDescriptor?.set) {
+            const setter = originalDescriptor.set;
+            Object.defineProperty(port, 'onmessage', {
+                get: originalDescriptor.get?.bind(port),
+                set(handler) {
+                    setter.call(port, handler);
+                    port.unref();
+                },
+                configurable: true,
+            });
+        }
+    };
 
-if (!window.CSS) window.CSS = {} as any;
-if (!window.CSS.supports) window.CSS.supports = () => true;
+    class UnrefMessageChannel extends MessageChannel {
+        constructor() {
+            super();
+            patchPort(this.port1);
+            patchPort(this.port2);
+        }
+    }
+    globalThis.MessageChannel = UnrefMessageChannel as typeof globalThis.MessageChannel;
+}
+globalThis.MessagePort ??= MessagePort as typeof globalThis.MessagePort;
+
+if (!globalThis.CSS) globalThis.CSS = {} as any;
+if (!globalThis.CSS.supports) globalThis.CSS.supports = () => true;
 
 // Mock envVars to handle import.meta.env in Jest
 jest.mock('envVars', () => ({
     PxGrafUrl: 'http://localhost:3000',
     PublicUrl: '',
     BasePath: ''
+}));
+
+// Centralized react-i18next mock for all test files
+jest.mock('react-i18next', () => ({
+    ...jest.requireActual('react-i18next'),
+    useTranslation: () => ({
+        t: (str: string) => str,
+        i18n: {
+            changeLanguage: () => Promise.resolve(),
+        },
+    }),
 }));

--- a/PxGraf.Frontend/jest.setup.ts
+++ b/PxGraf.Frontend/jest.setup.ts
@@ -11,10 +11,11 @@ globalThis.structuredClone ??= <T>(val: T): T => deserialize(serialize(val));
 globalThis.ReadableStream ??= ReadableStream as typeof globalThis.ReadableStream;
 globalThis.WritableStream ??= WritableStream as typeof globalThis.WritableStream;
 globalThis.TransformStream ??= TransformStream as typeof globalThis.TransformStream;
-// Polyfill MessageChannel/MessagePort for jsdom, with auto-unref on ports
+// Override MessageChannel with node:worker_threads version + auto-unref on ports
 // to prevent React scheduler's internal MessageChannel from keeping the Jest worker alive.
+// jsdom's built-in MessageChannel lacks unref(), so we always replace it.
 // Setting onmessage implicitly calls ref(), so we patch the setter to re-unref.
-if (globalThis.MessageChannel === undefined) {
+{
     const patchPort = (port: MessagePort) => {
         const originalDescriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(port), 'onmessage');
         if (originalDescriptor?.set) {

--- a/PxGraf.Frontend/package-lock.json
+++ b/PxGraf.Frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pxgraf",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pxgraf",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
@@ -12102,24 +12102,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/PxGraf.Frontend/package-lock.json
+++ b/PxGraf.Frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pxgraf",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pxgraf",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/PxGraf.Frontend/package.json
+++ b/PxGraf.Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxgraf",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -25,7 +25,7 @@
     "build": "tsc && vite build",
     "serve": "vite preview",
     "test": "jest -c jest.config.ts",
-    "test:ci": "npm run test -- --coverage --ci --testResultsProcessor=\"jest-sonar-reporter\" --reporters=default --reporters=jest-junit --watchAll=false --forceExit"
+    "test:ci": "npm run test -- --coverage --ci --testResultsProcessor=\"jest-sonar-reporter\" --reporters=default --reporters=jest-junit --watchAll=false"
   },
   "jestSonar": {
     "reportPath": "reports",

--- a/PxGraf.Frontend/src/components/CellCount/CellCount.test.tsx
+++ b/PxGraf.Frontend/src/components/CellCount/CellCount.test.tsx
@@ -3,18 +3,6 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CellCount from './CellCount';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 describe('Rendering test', () => {
     it('renders correctly with values within range', () => {
         const { asFragment } = render(<CellCount maximumSize={5} size={1} warningLimit={3} />);

--- a/PxGraf.Frontend/src/components/ChartTypeRejectionReasons/ChartTypeRejectionReasons.test.tsx
+++ b/PxGraf.Frontend/src/components/ChartTypeRejectionReasons/ChartTypeRejectionReasons.test.tsx
@@ -4,18 +4,6 @@ import UiLanguageContext from 'contexts/uiLanguageContext';
 import '@testing-library/jest-dom';
 import ChartTypeRejectionReasons from './ChartTypeRejectionReasons';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const setLanguage = jest.fn();
 const language = 'fi';
 const setLanguageTab = jest.fn();

--- a/PxGraf.Frontend/src/components/ChartTypeSelector/ChartTypeSelector.test.tsx
+++ b/PxGraf.Frontend/src/components/ChartTypeSelector/ChartTypeSelector.test.tsx
@@ -5,18 +5,6 @@ import '@testing-library/jest-dom';
 import { EditorContext } from '../../contexts/editorContext';
 import { VisualizationType } from '../../types/visualizationType';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const onTypeSelectedMock = jest.fn((value: string) => value);
 
 const mockTypes = ['foo', 'bar', 'baz'];

--- a/PxGraf.Frontend/src/components/DirectoryInfo/DirectoryInfo.test.tsx
+++ b/PxGraf.Frontend/src/components/DirectoryInfo/DirectoryInfo.test.tsx
@@ -19,18 +19,6 @@ jest.mock('envVars', () => ({
     BasePath: ''
 }));
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 jest.mock('api/services/table', () => ({
     ...jest.requireActual('api/services/table'),
     useTableQuery: () => {

--- a/PxGraf.Frontend/src/components/Header/Header.test.tsx
+++ b/PxGraf.Frontend/src/components/Header/Header.test.tsx
@@ -1,18 +1,6 @@
 import React from 'react';
 import Header from "./Header";
-import { act, render, waitFor } from '@testing-library/react';
-
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
+import { render, waitFor } from '@testing-library/react';
 
 jest.mock('envVars', () => ({
     PxGrafUrl: 'pxGrafUrl.fi/',

--- a/PxGraf.Frontend/src/components/InfoBubble/InfoBubble.test.tsx
+++ b/PxGraf.Frontend/src/components/InfoBubble/InfoBubble.test.tsx
@@ -3,18 +3,6 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import InfoBubble from './InfoBubble';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 describe('Rendering test', () => {
     it('renders correctly with popper hidden', () => {
         const { asFragment } = render(<InfoBubble info='foobar' ariaLabel='foo' />);

--- a/PxGraf.Frontend/src/components/LanguageSelector/LanguageSelector.test.tsx
+++ b/PxGraf.Frontend/src/components/LanguageSelector/LanguageSelector.test.tsx
@@ -4,18 +4,6 @@ import '@testing-library/jest-dom';
 import { LanguageSelector } from './LanguageSelector';
 import UiLanguageContext from 'contexts/uiLanguageContext';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const setLanguage = jest.fn();
 const language = 'fi';
 const setLanguageTab = jest.fn();

--- a/PxGraf.Frontend/src/components/MetaEditor/BasicDimensionEditor.test.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/BasicDimensionEditor.test.tsx
@@ -8,18 +8,6 @@ import UiLanguageContext from 'contexts/uiLanguageContext';
 import { EditorContext } from '../../contexts/editorContext';
 import { VisualizationType } from '../../types/visualizationType';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const setLanguage = jest.fn();
 const language = 'fi';
 const setLanguageTab = jest.fn();

--- a/PxGraf.Frontend/src/components/MetaEditor/ContentDimensionEditor.test.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/ContentDimensionEditor.test.tsx
@@ -8,18 +8,6 @@ import UiLanguageContext from 'contexts/uiLanguageContext';
 import { EditorContext } from '../../contexts/editorContext';
 import { VisualizationType } from '../../types/visualizationType';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const setLanguage = jest.fn();
 const language = 'fi';
 const setLanguageTab = jest.fn();

--- a/PxGraf.Frontend/src/components/MetaEditor/ContentDimensionValueEditor.test.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/ContentDimensionValueEditor.test.tsx
@@ -6,18 +6,6 @@ import { IDimensionValueEditions } from 'types/query';
 import ContentDimensionValueEditor from './ContentDimensionValueEditor';
 import UiLanguageContext from 'contexts/uiLanguageContext';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const setLanguage = jest.fn();
 const language = 'fi';
 const setLanguageTab = jest.fn();

--- a/PxGraf.Frontend/src/components/MetaEditor/DimensionEditor.test.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/DimensionEditor.test.tsx
@@ -8,18 +8,6 @@ import UiLanguageContext from 'contexts/uiLanguageContext';
 import { EditorContext } from '../../contexts/editorContext';
 import { VisualizationType } from '../../types/visualizationType';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const mockDimension: IDimension = {
     code: 'foo',
     name: {

--- a/PxGraf.Frontend/src/components/MetaEditor/EditorField.test.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/EditorField.test.tsx
@@ -3,18 +3,6 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import EditorField from './Editorfield';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const mockFunction = jest.fn();
 const mockLabel = 'label';
 const mockEditValue = 'editValue';

--- a/PxGraf.Frontend/src/components/MetaEditor/HeaderEditor.test.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/HeaderEditor.test.tsx
@@ -8,18 +8,6 @@ import { ICubeQuery } from '../../types/query';
 import { IEditorContentsResult } from '../../api/services/editor-contents';
 import { IEditorContentsResponse } from '../../types/editorContentsResponse';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const data: IEditorContentsResponse = {
     headerText:
     {

--- a/PxGraf.Frontend/src/components/MetaEditor/MetaEditor.test.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/MetaEditor.test.tsx
@@ -9,18 +9,6 @@ import { EditorContext } from 'contexts/editorContext';
 import { IEditorContentsResult } from '../../api/services/editor-contents';
 import { IEditorContentsResponse } from '../../types/editorContentsResponse';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const setLanguage = jest.fn();
 const language = 'fi';
 const setLanguageTab = jest.fn();

--- a/PxGraf.Frontend/src/components/MetaEditor/RevertButton.test.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/RevertButton.test.tsx
@@ -3,18 +3,6 @@ import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import RevertButton from "./RevertButton";
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(<RevertButton onClick={() => undefined} />);

--- a/PxGraf.Frontend/src/components/NestedList/NestedList.test.tsx
+++ b/PxGraf.Frontend/src/components/NestedList/NestedList.test.tsx
@@ -7,18 +7,6 @@ import NestedList from './NestedList';
 import { IDatabaseGroupContents } from 'types/tableListItems';
 import { ITableResult } from 'api/services/table';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 jest.mock('envVars', () => ({
     PxGrafUrl: 'pxGrafUrl.fi/',
     PublicUrl: 'publicUrl.fi/',

--- a/PxGraf.Frontend/src/components/NestedList/TableItem.test.tsx
+++ b/PxGraf.Frontend/src/components/NestedList/TableItem.test.tsx
@@ -6,18 +6,6 @@ import { MemoryRouter } from 'react-router-dom';
 import { TableItem } from './TableItem';
 import { EDatabaseTableError, IDatabaseTable } from '../../types/tableListItems';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 jest.mock('envVars', () => ({
     PxGrafUrl: 'pxGrafUrl.fi/',
     PublicUrl: 'publicUrl.fi/',

--- a/PxGraf.Frontend/src/components/NestedList/TableItem.tsx
+++ b/PxGraf.Frontend/src/components/NestedList/TableItem.tsx
@@ -43,7 +43,7 @@ export const TableItem: React.FC<ITableItemProps> = ({ currentPath, item, depth 
                 {item.error ?
                     <ErrorAlert sx={{ pl: depth * 4 }} severity="warning">
                         <AlertTitle>{`${item.name[displayLanguage] ?? item.fileName}`}</AlertTitle>
-                        {getErrorText(item.error)}
+                        {getErrorText(item.error, t)}
                     </ErrorAlert>
                     :
                     <React.Fragment>

--- a/PxGraf.Frontend/src/components/NestedList/TableListItem.test.tsx
+++ b/PxGraf.Frontend/src/components/NestedList/TableListItem.test.tsx
@@ -6,18 +6,6 @@ import { MemoryRouter } from 'react-router-dom';
 import { TableListItem } from './TableListItem';
 import { IDatabaseGroupHeader } from 'types/tableListItems';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 jest.mock('envVars', () => ({
     PxGrafUrl: 'pxGrafUrl.fi/',
     PublicUrl: 'publicUrl.fi/',

--- a/PxGraf.Frontend/src/components/Preview/Preview.test.tsx
+++ b/PxGraf.Frontend/src/components/Preview/Preview.test.tsx
@@ -192,18 +192,6 @@ const mockVisualizationSettings: IVisualizationSettings = {
     ]
 };
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 jest.mock('api/services/visualization', () => ({
     ...jest.requireActual('api/services/visualization'),
     useVisualizationQuery: () => {

--- a/PxGraf.Frontend/src/components/SaveDialog/SaveDialog.test.tsx
+++ b/PxGraf.Frontend/src/components/SaveDialog/SaveDialog.test.tsx
@@ -5,18 +5,6 @@ import { SaveDialog } from './SaveDialog';
 import { EditorContext } from '../../contexts/editorContext';
 import { VisualizationType } from '../../types/visualizationType';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const onCloseMock = jest.fn();
 const onSaveMock = jest.fn(() => { });
 const setIsDraftMock = jest.fn();

--- a/PxGraf.Frontend/src/components/SaveResultDialog/ErrorDialogContent.test.tsx
+++ b/PxGraf.Frontend/src/components/SaveResultDialog/ErrorDialogContent.test.tsx
@@ -3,18 +3,6 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ErrorDialogContent } from './ErrorDialogContent';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(<ErrorDialogContent />);

--- a/PxGraf.Frontend/src/components/SaveResultDialog/SaveResultDialog.test.tsx
+++ b/PxGraf.Frontend/src/components/SaveResultDialog/SaveResultDialog.test.tsx
@@ -7,18 +7,6 @@ import { ISaveQueryResult } from 'api/services/queries';
 import { EditorContext } from '../../contexts/editorContext';
 import { VisualizationType } from '../../types/visualizationType';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const mockSuccessMutation: ISaveQueryResult = {
     isPending: false,
     isError: false,

--- a/PxGraf.Frontend/src/components/SaveResultDialog/SuccessDialogContent.test.tsx
+++ b/PxGraf.Frontend/src/components/SaveResultDialog/SuccessDialogContent.test.tsx
@@ -15,7 +15,7 @@ const mockT = jest.fn((key: string) => {
 
 const mockI18n = {
     language: 'en',
-    changeLanguage: () => new Promise(() => { })
+    changeLanguage: () => Promise.resolve()
 };
 
 jest.mock('react-i18next', () => ({

--- a/PxGraf.Frontend/src/components/SavedQueryFinder/SavedQueryFinder.test.tsx
+++ b/PxGraf.Frontend/src/components/SavedQueryFinder/SavedQueryFinder.test.tsx
@@ -1,20 +1,8 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { HashRouter } from 'react-router-dom';
 import { SavedQueryFinder } from './SavedQueryFinder';
-
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
 
 jest.mock('envVars', () => ({
     PxGrafUrl: 'pxGrafUrl.fi/',
@@ -36,14 +24,12 @@ describe('Rendering test', () => {
 });
 
 describe('Assertion test', () => {
-    it('Renders dialog if opened, eliminates dialog if closed', () => {
+    it('Renders dialog if opened, eliminates dialog if closed', async () => {
         render(<HashRouter><SavedQueryFinder /></HashRouter>);
         fireEvent.click(screen.getByText('savedQuery.dialogButtonTxt'));
         expect(screen.getByText('savedQuery.dialogTitleTxt')).toBeInTheDocument();
         fireEvent.click(screen.getByText('savedQuery.closeButton'));
-        setTimeout(() => {
-            expect(screen.queryByText('savedQuery.dialogTitleTxt')).toBeFalsy();
-        }, 1000);
+        await waitForElementToBeRemoved(() => screen.queryByText('savedQuery.dialogTitleTxt'));
     });
 
     it('Renders initial input in the input field', () => {

--- a/PxGraf.Frontend/src/components/TableInfo/TableInfo.test.tsx
+++ b/PxGraf.Frontend/src/components/TableInfo/TableInfo.test.tsx
@@ -32,18 +32,6 @@ const mockTableQueryResult = {
     }
 }
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => {}),
-            },
-        };
-    },
-}));
-
 jest.mock('api/services/table', () => ({
     ...jest.requireActual('api/services/table'),
     useTableQuery: () => {

--- a/PxGraf.Frontend/src/components/TableInfo/TableInfo.tsx
+++ b/PxGraf.Frontend/src/components/TableInfo/TableInfo.tsx
@@ -30,7 +30,7 @@ export const TableInfo: React.FC<ITableInfoProps> = ({ path, item }) => {
                 {item.error ?
                     <ErrorAlert severity="warning">
                         <AlertTitle>{`${item.name[displayLanguage] ?? item.fileName}`}</AlertTitle>
-                        {getErrorText(item.error)}
+                        {getErrorText(item.error, t)}
                     </ErrorAlert>
                     :
                     <ListItemText primary={

--- a/PxGraf.Frontend/src/components/VariableSelection/DefaultSelectableDimensionSelection.test.tsx
+++ b/PxGraf.Frontend/src/components/VariableSelection/DefaultSelectableDimensionSelection.test.tsx
@@ -67,18 +67,6 @@ const setSelectedVisualizationUserInput = jest.fn();
 const visualizationSettingsUserInput = null;
 const setVisualizationSettingsUserInput = jest.fn();
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 describe('Rendering test', () => {
     it('renders correctly with default selectable', () => {
         const { asFragment } = render(

--- a/PxGraf.Frontend/src/components/VariableSelection/DimensionSelection.test.tsx
+++ b/PxGraf.Frontend/src/components/VariableSelection/DimensionSelection.test.tsx
@@ -75,18 +75,6 @@ const availableUiLanguages = ['fi', 'en', 'sv'];
 const uiContentLanguage = "fi";
 const setUiContentLanguage = jest.fn();
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(

--- a/PxGraf.Frontend/src/components/VariableSelection/DimensionSelectionList.test.tsx
+++ b/PxGraf.Frontend/src/components/VariableSelection/DimensionSelectionList.test.tsx
@@ -355,18 +355,6 @@ const availableUiLanguages = ['fi', 'en', 'sv'];
 const uiContentLanguage = "fi";
 const setUiContentLanguage = jest.fn();
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(

--- a/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/AllDimensionSelection.test.tsx
+++ b/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/AllDimensionSelection.test.tsx
@@ -2,18 +2,6 @@ import React from 'react';
 import { render } from "@testing-library/react";
 import AllDimensionSelection from "./AllDimensionSelection";
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(<AllDimensionSelection

--- a/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/ManualPickDimensionSelection.test.tsx
+++ b/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/ManualPickDimensionSelection.test.tsx
@@ -54,18 +54,6 @@ const availableUiLanguages = ['fi', 'en', 'sv'];
 const uiContentLanguage = "fi";
 const setUiContentLanguage = jest.fn();
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(

--- a/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/StartingFromDimensionSelection.test.tsx
+++ b/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/StartingFromDimensionSelection.test.tsx
@@ -42,18 +42,6 @@ const mockDimensionValues: IDimensionValue[] = [
     }
 ];
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(<StartingFromDimensionSelection

--- a/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/TopNDimensionSelection.test.tsx
+++ b/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/TopNDimensionSelection.test.tsx
@@ -3,18 +3,6 @@ import { fireEvent, render, screen } from "@testing-library/react";
 
 import TopNDimensionSelection from "./TopNDimensionSelection";
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const mockChangeFunction = jest.fn();
 
 describe('Rendering test', () => {

--- a/PxGraf.Frontend/src/components/VariableSelection/ResultList.test.tsx
+++ b/PxGraf.Frontend/src/components/VariableSelection/ResultList.test.tsx
@@ -42,18 +42,6 @@ const mockDimensionValues: IDimensionValue[] = [
     }
 ];
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(<ResultList

--- a/PxGraf.Frontend/src/components/VariableSelection/SelectabilitySwitch.test.tsx
+++ b/PxGraf.Frontend/src/components/VariableSelection/SelectabilitySwitch.test.tsx
@@ -3,18 +3,6 @@ import { render } from "@testing-library/react";
 
 import SelectabilitySwitch from "./SelectabilitySwitch";
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(<SelectabilitySwitch

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/MultiselectableSelector.test.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/MultiselectableSelector.test.tsx
@@ -57,18 +57,6 @@ const mockvisualizationOptions: IVisualizationOptions = {
 	allowManualPivot: false, sortingOptions: null, allowMultiselect: true
 } as unknown as IVisualizationOptions;
 
-jest.mock('react-i18next', () => ({
-	...jest.requireActual('react-i18next'),
-	useTranslation: () => {
-		return {
-			t: (str: string) => str,
-			i18n: {
-				changeLanguage: () => new Promise(() => null),
-			},
-		};
-	},
-}));
-
 describe('Rendering test', () => {
 	it('renders correctly', () => {
 		const { asFragment } = render(

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/TablePivotSettings.test.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/TablePivotSettings.test.tsx
@@ -10,18 +10,6 @@ import { EditorContext } from '../../../contexts/editorContext';
 import { VisualizationType } from '../../../types/visualizationType';
 import { IVisualizationOptions } from '../../../types/editorContentsResponse';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const mockVisualizationRules: IVisualizationOptions = {
     allowManualPivot: false,
     sortingOptions: null,

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/MarkerScaler.test.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/MarkerScaler.test.tsx
@@ -7,18 +7,6 @@ import { EditorContext } from '../../../contexts/editorContext';
 import { VisualizationType } from '../../../types/visualizationType';
 import { IVisualizationOptions } from '../../../types/editorContentsResponse';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const mockVisualizationRules: IVisualizationOptions = {
     allowManualPivot: null,
     sortingOptions: null,

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/VisualizationSettingsSwitch.test.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/VisualizationSettingsSwitch.test.tsx
@@ -4,18 +4,6 @@ import VisualizationSettingsSwitch from "./VisualizationSettingsSwitch";
 import { EditorContext } from '../../../contexts/editorContext';
 import { VisualizationType } from '../../../types/visualizationType';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const mockSettingsChangedHandler = jest.fn();
 const mockVisualizationSettings = { showDataPoints: false };
 

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/VisualizationSettingsControl.test.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/VisualizationSettingsControl.test.tsx
@@ -9,18 +9,6 @@ import { EditorContext } from '../../contexts/editorContext';
 import { VisualizationType } from '../../types/visualizationType';
 import { IVisualizationOptions } from '../../types/editorContentsResponse';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const mockVisualizationRules: IVisualizationOptions = {
     allowManualPivot: false,
     sortingOptions: {

--- a/PxGraf.Frontend/src/utils/ApiHelpers.test.ts
+++ b/PxGraf.Frontend/src/utils/ApiHelpers.test.ts
@@ -44,14 +44,15 @@ const mockBackendOldQueryRespons: IFetchSavedQueryResponse = {
 describe('buildCubeQuery tests', () => {
     it('Should build an object', () => {
         const result = buildCubeQuery(mockQuery, mockMetaEdits, mockIdStack);
-        expect(result).toBeTruthy();
+        expect(result).toHaveProperty('tableReference', { name: 'baz', hierarchy: ['foo', 'bar'] });
+        expect(result).toHaveProperty('variableQueries.foo.selectable', false);
+        expect(result).toHaveProperty('variableQueries.foo.valueEdits');
     });
 });
 
 describe('buildTableReference tests', () => {
     it('Should build an object', () => {
         const result = buildTableReference(mockIdStack);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ name: 'baz', hierarchy: [ 'foo', 'bar' ] });
     });
 });
@@ -64,16 +65,7 @@ jest.mock('envVars', () => ({
 describe('pxGrafUrl tests', () => {
     it('Should build a correct format string', () => {
         const result: string = pxGrafUrl('foobar');
-        expect(result).toBeTruthy();
         expect(result).toEqual('mockedUrl.fi/foobar');
-    });
-});
-
-describe('buildTableReference tests', () => {
-    it('Should build an object', () => {
-        const result = buildTableReference(mockIdStack);
-        expect(result).toBeTruthy();
-        expect(result).toEqual({ name: 'baz', hierarchy: [ 'foo', 'bar' ] });
     });
 });
 

--- a/PxGraf.Frontend/src/utils/ChartSettingHelpers.test.ts
+++ b/PxGraf.Frontend/src/utils/ChartSettingHelpers.test.ts
@@ -309,104 +309,85 @@ const mockQueryWithSelectable: Query = {
 describe('getValidatedSettings tests', () => {
     it('Should return the correct object on Table', () => {
         const result = getValidatedSettings(mockVisualizationSettings, VisualizationType.Table, mockSortingOptions, mockDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ rowVariableCodes: [ 'foo' ], columnVariableCodes: [  ] });
     });
 
     it('Should not throw an exception with zero variables', () => {
-        function testTableWithZeroVariables() {
-            getValidatedSettings(mockVisualizationSettings, VisualizationType.Table, mockSortingOptions, mockZeroDimensions, mockQuery);
-        }
-        expect(testTableWithZeroVariables).not.toThrow(TypeError);
+        expect(() => getValidatedSettings(mockVisualizationSettings, VisualizationType.Table, mockSortingOptions, mockZeroDimensions, mockQuery)).not.toThrow(TypeError);
     });
 
     it('Should return the correct default pivot on Table with two variables', () => {
         const result = getValidatedSettings(mockDefaultTableVisualizationSettings, VisualizationType.Table, mockSortingOptions, mockTableTwoDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ rowVariableCodes: ['bar'], columnVariableCodes: ['foo'] });
     });
 
     it('Should return the correct default pivot on Table with three variables', () => {
         const result = getValidatedSettings(mockDefaultTableVisualizationSettings, VisualizationType.Table, mockSortingOptions, mockTableThreeDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ rowVariableCodes: ['baz', 'bar'], columnVariableCodes: ['foo'] });
     });
 
     it('Should return the correct default pivot on Table with four variables and with a single value variable', () => {
         const result = getValidatedSettings(mockDefaultTableVisualizationSettings, VisualizationType.Table, mockSortingOptions, mockTableFourDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ rowVariableCodes: ['baz', 'bar', 'foobar'], columnVariableCodes: ['foo'] });
     });
 
     it('Should return the correct default pivot on Table with four variables, with a single value variable and a selectable variable', () => {
         const result = getValidatedSettings(mockDefaultTableVisualizationSettings, VisualizationType.Table, mockSortingOptions, mockTableFourDimensions, mockQueryWithSelectable);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ rowVariableCodes: ['bar', 'foo', 'foobar'], columnVariableCodes: ['baz'] });
     });
 
     it('Should return the correct object on LineChart', () => {
         const result = getValidatedSettings(mockVisualizationSettings, VisualizationType.LineChart, mockSortingOptions, mockDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ cutYAxis: false, multiselectableVariableCode: null, showDataPoints: false });
     });
     
     it('Should return the correct object on PieChart', () => {
         const result = getValidatedSettings(mockVisualizationSettings, VisualizationType.PieChart, mockSortingOptions, mockDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ showDataPoints: false, sorting: 'foo' });
     });
 
     it('Should return the correct object on VerticalBarChart', () => {
         const result = getValidatedSettings(mockVisualizationSettings, VisualizationType.VerticalBarChart, mockSortingOptions, mockDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ matchXLabelsToEnd: false, showDataPoints: false });
     });
 
     it('Should return the correct object on GroupVerticalBarChart', () => {
         const result = getValidatedSettings(mockVisualizationSettings, VisualizationType.GroupVerticalBarChart, mockSortingOptions, mockDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ pivotRequested: false, matchXLabelsToEnd: false, showDataPoints: false });
     });
 
     it('Should return the correct object on StackedVerticalBarChart', () => {
         const result = getValidatedSettings(mockVisualizationSettings, VisualizationType.StackedVerticalBarChart, mockSortingOptions, mockDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ pivotRequested: false, matchXLabelsToEnd: false, showDataPoints: false });
     });
 
     it('Should return the correct object on PercentVerticalBarChart', () => {
         const result = getValidatedSettings(mockVisualizationSettings, VisualizationType.PercentVerticalBarChart, mockSortingOptions, mockDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ pivotRequested: false, matchXLabelsToEnd: false, showDataPoints: false });
     });
 
     it('Should return the correct object on HorizontalBarChart', () => {
         const result = getValidatedSettings(mockVisualizationSettings, VisualizationType.HorizontalBarChart, mockSortingOptions, mockDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ sorting: 'foo', showDataPoints: false });
     });
 
     it('Should return the correct object on GroupHorizontalBarChart', () => {
         const result = getValidatedSettings(mockVisualizationSettings, VisualizationType.GroupHorizontalBarChart, mockSortingOptions, mockDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ sorting: 'foo', pivotRequested: false, showDataPoints: false });
     });
 
     it('Should return the correct object on StackedHorizontalBarChart', () => {
         const result = getValidatedSettings(mockVisualizationSettings, VisualizationType.StackedHorizontalBarChart, mockSortingOptions, mockDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ sorting: 'foo', pivotRequested: false, showDataPoints: false });
     });
 
     it('Should return the correct object on PercentHorizontalBarChart', () => {
         const result = getValidatedSettings(mockVisualizationSettings, VisualizationType.PercentHorizontalBarChart, mockSortingOptions, mockDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ sorting: 'foo', pivotRequested: false, showDataPoints: false });
     });
 
     it('Should return the correct object on ScatterPlot', () => {
         const result = getValidatedSettings(mockVisualizationSettings, VisualizationType.ScatterPlot, mockSortingOptions, mockDimensions, mockQuery);
-        expect(result).toBeTruthy();
         expect(result).toEqual({ cutYAxis: false, markerSize: 100 });
     });
 });

--- a/PxGraf.Frontend/src/utils/editorHelpers.test.ts
+++ b/PxGraf.Frontend/src/utils/editorHelpers.test.ts
@@ -38,7 +38,6 @@ describe('getDefaultQueries tests', () => {
             }
         }
         const result = getDefaultQueries(mockDimensions);
-        expect(result).toBeTruthy();
         expect(result).toEqual(expected);
     });
 });
@@ -47,7 +46,6 @@ describe('resolveVariables tests', () => {
     it('Should return the correct object', () => {
         const expected: IDimension[] = [{ code: 'foo', name: { fi: 'nimi' }, type: EDimensionType.Content, values: [] }];
         const result = resolveDimensions(mockDimensions, {'foo': ['bar', 'baz']});
-        expect(result).toBeTruthy();
         expect(result).toEqual(expected);
     });
 });
@@ -75,7 +73,6 @@ describe('getVisualizationOptionsForType tests', () => {
             }
         ];
         const result = getVisualizationOptionsForVisualizationType(mockVisualizationOptions, VisualizationType.LineChart);
-        expect(result).toBeTruthy();
         expect(result).toEqual(mockVisualizationOptions[0]);
     });
 

--- a/PxGraf.Frontend/src/utils/editorHelpers.ts
+++ b/PxGraf.Frontend/src/utils/editorHelpers.ts
@@ -1,7 +1,6 @@
 import { IDimension } from 'types/cubeMeta';
 import { FilterType, IDimensionQuery } from 'types/query';
 import { getDefaultFilter } from './dimensionSelectionHelpers';
-import { useTranslation } from 'react-i18next';
 import { EDatabaseTableError } from '../types/tableListItems';
 import { IVisualizationOptions } from '../types/editorContentsResponse';
 import { VisualizationType } from '../types/visualizationType';
@@ -22,8 +21,7 @@ export const resolveDimensions = (dimensions: IDimension[], resolvedDimensionCod
     return dimensions.map(v => { return { code: v.code, name: v.name, type: v.type, values: v.values.filter(val => resolvedDimensionCodes?.[v.code]?.includes(val.code)) } as IDimension });
 }
 
-export const getErrorText = (error: EDatabaseTableError) => {
-    const { t } = useTranslation();
+export const getErrorText = (error: EDatabaseTableError, t: (key: string) => string) => {
     switch (error) {
         case EDatabaseTableError.contentDimensionMissing:
             return t("error.contentVariableMissing");

--- a/PxGraf.Frontend/src/views/Editor/Editor.test.tsx
+++ b/PxGraf.Frontend/src/views/Editor/Editor.test.tsx
@@ -19,7 +19,9 @@ import { VisualizationType } from '../../types/visualizationType';
 import { IEditorContentsResult } from '../../api/services/editor-contents';
 import { EditorContext } from '../../contexts/editorContext';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+});
 const language = "fi";
 const setLanguage = jest.fn();
 const languageTab = "fi";
@@ -27,6 +29,10 @@ const setLanguageTab = jest.fn();
 const availableUiLanguages = ["fi", "sv", "en"];
 const uiContentLanguage = "fi";
 const setUiContentLanguage = jest.fn();
+
+afterEach(() => {
+    queryClient.clear();
+});
 
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
@@ -41,18 +47,6 @@ jest.mock('envVars', () => ({
     PxGrafUrl: 'pxGrafUrl.fi/',
     PublicUrl: 'publicUrl.fi/',
     BasePath: ''
-}));
-
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => ({})),
-            },
-        };
-    },
 }));
 
 jest.mock('api/services/cube-meta', () => ({
@@ -233,7 +227,7 @@ const mockEditorContentsResult: IEditorContentsResult = {
     }
 }
 
-const mockCubeMetaResult: ICubeMetaResult = {
+const initialMockCubeMetaResult: ICubeMetaResult = {
     isLoading: false,
     isError: false,
     data: {
@@ -262,6 +256,8 @@ const mockCubeMetaResult: ICubeMetaResult = {
         ]
     }
 }
+
+let mockCubeMetaResult: ICubeMetaResult;
 
 const mockTableValidationResult: IValidateTableMetaDataResult = {
     isLoading: false,
@@ -339,10 +335,14 @@ jest.mock('api/services/validate-table-metadata', () => ({
     useValidateTableMetadataQuery: () => mockResult,
 }));
 
+beforeEach(() => {
+    mockCubeMetaResult = structuredClone(initialMockCubeMetaResult);
+    mockResult = mockTableValidationResult;
+});
+
 describe('Rendering test', () => {
     beforeAll(() => {
         expect.addSnapshotSerializer(serializer);
-        mockResult = mockTableValidationResult;
     });
 
     it('renders correctly', () => {
@@ -417,39 +417,9 @@ describe('Assertion tests', () => {
     });
 
     it('loads query data from location state', () => {
-        mockResult = mockTableValidationResult;
-        mockCubeMetaResult.isLoading = false;
-        mockCubeMetaResult.isError = false;
-        mockCubeMetaResult.data = {
-            defaultLanguage: 'fi',
-            availableLanguages: ['fi'],
-            additionalProperties: {},
-            dimensions: [
-                {
-                    code: 'code',
-                    name: {
-                        'fi': 'variableName'
-                    },
-                    type: EDimensionType.Content,
-                    values: [
-                        {
-                            code: 'variableValueCode',
-                            name: {
-                                'fi': 'variableValueName'
-                            },
-                            isVirtual: false,
-                            additionalProperties: {},
-                        }
-                    ],
-                    additionalProperties: {}
-                }
-            ]
-        };
-
         const setSelectedVisualizationUserInput = jest.fn();
         const setLoadedQueryId = jest.fn();
         const setLoadedQueryIsDraft = jest.fn();
-        const originalUseContext = React.useContext;
 
         const mockEditorContext = {
             cubeQuery: { variableQueries: {} },
@@ -472,20 +442,13 @@ describe('Assertion tests', () => {
             setPublicationWebhookEnabled: jest.fn()
         };
 
-        // Mock useContext to return the mockEditorContext for EditorContext
-        jest.spyOn(React, 'useContext').mockImplementation(context => {
-            if (context === EditorContext) {
-                return mockEditorContext;
-            }
-            // Return the original context for other contexts
-            return originalUseContext(context);
-        });
-
         render(
             <QueryClientProvider client={queryClient}>
                 <NavigationProvider>
                     <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                        <Editor />
+                        <EditorContext.Provider value={mockEditorContext}>
+                            <Editor />
+                        </EditorContext.Provider>
                     </UiLanguageContext.Provider>
                 </NavigationProvider>
             </QueryClientProvider>
@@ -494,34 +457,10 @@ describe('Assertion tests', () => {
         expect(setLoadedQueryId).toHaveBeenCalledWith('test-query-id');
         expect(setLoadedQueryIsDraft).toHaveBeenCalledWith(true);
         expect(setSelectedVisualizationUserInput).toHaveBeenCalledWith(EVisualizationType.HorizontalBarChart);
-
-        jest.restoreAllMocks();
     });
 
     it('calls setPublicationWebhookEnabled when editorContentsResponse has publicationWebhookEnabled property', () => {
-        mockResult = mockTableValidationResult;
-        mockCubeMetaResult.isLoading = false;
-        mockCubeMetaResult.isError = false;
-        mockCubeMetaResult.data = {
-            defaultLanguage: 'fi',
-            availableLanguages: ['fi'],
-            additionalProperties: {},
-            dimensions: [{
-                code: 'code',
-                name: { 'fi': 'variableName' },
-                type: EDimensionType.Content,
-                values: [{
-                    code: 'variableValueCode',
-                    name: { 'fi': 'variableValueName' },
-                    isVirtual: false,
-                    additionalProperties: {}
-                }],
-                additionalProperties: {}
-            }]
-        };
-
         const setPublicationWebhookEnabled = jest.fn();
-        const originalUseContext = React.useContext;
 
         const mockEditorContextWithPublication = {
             cubeQuery: { variableQueries: {} },
@@ -544,19 +483,13 @@ describe('Assertion tests', () => {
             setPublicationWebhookEnabled
         };
 
-        // Mock useContext to return our mock for EditorContext
-        jest.spyOn(React, 'useContext').mockImplementation(context => {
-            if (context === EditorContext) {
-                return mockEditorContextWithPublication;
-            }
-            return originalUseContext(context);
-        });
-
         render(
             <QueryClientProvider client={queryClient}>
                 <NavigationProvider>
                     <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                        <Editor />
+                        <EditorContext.Provider value={mockEditorContextWithPublication}>
+                            <Editor />
+                        </EditorContext.Provider>
                     </UiLanguageContext.Provider>
                 </NavigationProvider>
             </QueryClientProvider>
@@ -564,7 +497,5 @@ describe('Assertion tests', () => {
 
         // Verify that setPublicationWebhookEnabled was called with true (from the mocked API response)
         expect(setPublicationWebhookEnabled).toHaveBeenCalledWith(true);
-
-        jest.restoreAllMocks();
     });
 });

--- a/PxGraf.Frontend/src/views/Editor/EditorFilterSection.test.tsx
+++ b/PxGraf.Frontend/src/views/Editor/EditorFilterSection.test.tsx
@@ -34,18 +34,6 @@ const mockQuery: Query = {
     }
 }
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => {}),
-            },
-        };
-    },
-}));
-
 const setLanguage = jest.fn();
 const language = 'fi';
 

--- a/PxGraf.Frontend/src/views/Editor/EditorFooterSection.test.tsx
+++ b/PxGraf.Frontend/src/views/Editor/EditorFooterSection.test.tsx
@@ -3,18 +3,6 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import EditorFooterSection from './EditorFooterSection';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => {}),
-            },
-        };
-    },
-}));
-
 describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(<EditorFooterSection />);

--- a/PxGraf.Frontend/src/views/Editor/EditorMetaSection.test.tsx
+++ b/PxGraf.Frontend/src/views/Editor/EditorMetaSection.test.tsx
@@ -220,18 +220,6 @@ const editorContentsResult: IEditorContentsResult = {
 
 const selectedVisualizationMock: VisualizationType = VisualizationType.HorizontalBarChart
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 const language = "fi";
 const setLanguage = jest.fn();
 const languageTab = "fi";

--- a/PxGraf.Frontend/src/views/Editor/EditorPreviewSection.test.tsx
+++ b/PxGraf.Frontend/src/views/Editor/EditorPreviewSection.test.tsx
@@ -239,18 +239,6 @@ const mockEditorContentsEmptyVisualizationsAndRejections: IEditorContentsResult 
     }
 };
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => null),
-            },
-        };
-    },
-}));
-
 jest.mock('api/services/visualization', () => ({
     ...jest.requireActual('api/services/visualization'),
     useVisualizationQuery: (

--- a/PxGraf.Frontend/src/views/QueryLoader/QueryLoader.test.tsx
+++ b/PxGraf.Frontend/src/views/QueryLoader/QueryLoader.test.tsx
@@ -19,25 +19,13 @@ jest.mock('envVars', () => ({
     BasePath: ''
 }));
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => {}),
-            },
-        };
-    },
-}));
-
 describe('Rendering test', () => {
 
-    it('renders correctly', () => {
+    it('renders correctly', async () => {
         const { asFragment } = render(
             <HashRouter><QueryLoader /></HashRouter>
         );
-        waitFor(() => {
+        await waitFor(() => {
             expect(asFragment()).toMatchSnapshot();
         });
     });

--- a/PxGraf.Frontend/src/views/TableListSelection/TableListSelection.test.tsx
+++ b/PxGraf.Frontend/src/views/TableListSelection/TableListSelection.test.tsx
@@ -6,18 +6,6 @@ import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import TableListSelection from './TableListSelection';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => {}),
-            },
-        };
-    },
-}));
-
 jest.mock('envVars', () => ({
     PxGrafUrl: 'pxGrafUrl.fi/',
     PublicUrl: 'publicUrl.fi/',

--- a/PxGraf.Frontend/src/views/TableTreeSelection/TableTreeSelection.test.tsx
+++ b/PxGraf.Frontend/src/views/TableTreeSelection/TableTreeSelection.test.tsx
@@ -7,18 +7,6 @@ import { MemoryRouter } from 'react-router-dom';
 import TableTreeSelection from './TableTreeSelection';
 import { NavigationProvider } from 'contexts/navigationContext';
 
-jest.mock('react-i18next', () => ({
-    ...jest.requireActual('react-i18next'),
-    useTranslation: () => {
-        return {
-            t: (str: string) => str,
-            i18n: {
-                changeLanguage: () => new Promise(() => ({})),
-            },
-        };
-    },
-}));
-
 jest.mock('envVars', () => ({
     PxGrafUrl: 'pxGrafUrl.fi/',
     PublicUrl: 'publicUrl.fi/',


### PR DESCRIPTION
- Removed mocked translations from various test files to streamline tests.
- Updated assertions in tests to check for specific properties instead of using truthy checks.
- Enhanced async handling in tests to ensure proper rendering and state management.
- Adjusted error handling in utility functions to accept translation function as a parameter.
- Improved overall test readability and maintainability.