### PR TITLE
[Fix] Refactor SqFileInterface to use async file operations

### DIFF
--- a/PxGraf/Controllers/QueryMetaController.cs
+++ b/PxGraf/Controllers/QueryMetaController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Px.Utils.Language;
 using Px.Utils.Models.Metadata.ExtensionMethods;
@@ -44,7 +44,7 @@ namespace PxGraf.Controllers
             using (_logger.BeginScope(logScope))
             {
                 _logger.LogDebug("Query meta requested GET: api/sq/meta/");
-                if (_sqFileInterface.SavedQueryExists(savedQueryId, Configuration.Current.SavedQueryDirectory))
+                if (await _sqFileInterface.SavedQueryExists(savedQueryId, Configuration.Current.SavedQueryDirectory))
                 {
                     using (_logger.BeginScope(new Dictionary<string, object> { [LoggerConstants.SQ_ID] = savedQueryId }))
                     {
@@ -94,7 +94,7 @@ namespace PxGraf.Controllers
         {
             if (savedQuery.Archived)
             {
-                if (_sqFileInterface.ArchiveCubeExists(id, Configuration.Current.ArchiveFileDirectory))
+                if (await _sqFileInterface.ArchiveCubeExists(id, Configuration.Current.ArchiveFileDirectory))
                 {
                     ArchiveCube archiveCube = await _sqFileInterface.ReadArchiveCubeFromFile(id, Configuration.Current.ArchiveFileDirectory);
                     return archiveCube.Meta;

--- a/PxGraf/Controllers/SqController.cs
+++ b/PxGraf/Controllers/SqController.cs
@@ -67,7 +67,7 @@ namespace PxGraf.Controllers
             using (_logger.BeginScope(logScope))
             {
                 _logger.LogDebug("Saved query requested.");
-                if (_sqFileInterface.SavedQueryExists(savedQueryId, Configuration.Current.SavedQueryDirectory))
+                if (await _sqFileInterface.SavedQueryExists(savedQueryId, Configuration.Current.SavedQueryDirectory))
                 {
                     using (_logger.BeginScope(new Dictionary<string, object> { [LoggerConstants.SQ_ID] = savedQueryId }))
                     {
@@ -170,7 +170,7 @@ namespace PxGraf.Controllers
                     if (validTypes.Contains(visualizationSettings.VisualizationType))
                     {
                         SavedQuery savedQuery = new(parameters.Query, archived: false, visualizationSettings, DateTime.Now, parameters.Draft);
-                        await _sqFileInterface.SerializeToFile(fileName, Configuration.Current.SavedQueryDirectory, savedQuery);
+                        await _sqFileInterface.SerializeToSqFileAsync(fileName, Configuration.Current.SavedQueryDirectory, savedQuery);
                         WebhookPublicationResult webhookResult = new () { Status = QueryPublicationStatus.Unpublished };
 
                         // Trigger webhook for non-draft queries only if webhook is enabled
@@ -244,10 +244,10 @@ namespace PxGraf.Controllers
                     if (validTypes.Contains(visualizationSettings.VisualizationType))
                     {
                         SavedQuery savedQuery = new(parameters.Query, archived: true, visualizationSettings, DateTime.Now, parameters.Draft);
-                        await _sqFileInterface.SerializeToFile(queryFileName, Configuration.Current.SavedQueryDirectory, savedQuery);
+                        await _sqFileInterface.SerializeToSqFileAsync(queryFileName, Configuration.Current.SavedQueryDirectory, savedQuery);
 
                         string archiveName = $"{guid}.sqa";
-                        await _sqFileInterface.SerializeToFile(archiveName, Configuration.Current.ArchiveFileDirectory, new ArchiveCube(matrix));
+                        await _sqFileInterface.SerializeToArchiveFileAsync(archiveName, Configuration.Current.ArchiveFileDirectory, new ArchiveCube(matrix));
 
                         WebhookPublicationResult webhookResult = new() { Status = QueryPublicationStatus.Unpublished };
 
@@ -296,7 +296,7 @@ namespace PxGraf.Controllers
             using (_logger.BeginScope(logScope))
             {
                 _logger.LogDebug("Re-archiving query.");
-                if (_sqFileInterface.SavedQueryExists(request.SqId, Configuration.Current.SavedQueryDirectory))
+                if (await _sqFileInterface.SavedQueryExists(request.SqId, Configuration.Current.SavedQueryDirectory))
                 {
                     using (_logger.BeginScope(new Dictionary<string, object> { [LoggerConstants.SQ_ID] = request.SqId }))
                     {
@@ -318,10 +318,10 @@ namespace PxGraf.Controllers
                             if (validTypes.Contains(baseQuery.Settings.VisualizationType))
                             {
                                 SavedQuery savedQuery = new(baseQuery.Query, archived: true, baseQuery.Settings, DateTime.Now, request.Draft);
-                                await _sqFileInterface.SerializeToFile(queryFileName, Configuration.Current.SavedQueryDirectory, savedQuery);
+                                await _sqFileInterface.SerializeToSqFileAsync(queryFileName, Configuration.Current.SavedQueryDirectory, savedQuery);
 
                                 string archiveName = $"{guid}.sqa";
-                                await _sqFileInterface.SerializeToFile(archiveName, Configuration.Current.ArchiveFileDirectory, new ArchiveCube(matrix));
+                                await _sqFileInterface.SerializeToArchiveFileAsync(archiveName, Configuration.Current.ArchiveFileDirectory, new ArchiveCube(matrix));
 
                                 WebhookPublicationResult webhookResult = new() { Status = QueryPublicationStatus.Unpublished };
 
@@ -392,7 +392,7 @@ namespace PxGraf.Controllers
                 return false;
             }
 
-            if (_sqFileInterface.SavedQueryExists(id, Configuration.Current.SavedQueryDirectory))
+            if (await _sqFileInterface.SavedQueryExists(id, Configuration.Current.SavedQueryDirectory))
             {
                 SavedQuery savedQuery = await _sqFileInterface.ReadSavedQueryFromFile(id, Configuration.Current.SavedQueryDirectory);
                 return savedQuery.Draft;

--- a/PxGraf/Controllers/VisualizationController.cs
+++ b/PxGraf/Controllers/VisualizationController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Px.Utils.Models.Data.DataValue;
 using Px.Utils.Models.Metadata.Enums;
@@ -103,7 +103,7 @@ namespace PxGraf.Controllers
                     return BadRequest();
                 }
 
-                if (_sqFileInterface.SavedQueryExists(sqId, Configuration.Current.SavedQueryDirectory))
+                if (await _sqFileInterface.SavedQueryExists(sqId, Configuration.Current.SavedQueryDirectory))
                 {
                     _auditLogService.LogAuditEvent(
                         action: CONTROLLER_PATH,

--- a/PxGraf/PxGraf.csproj
+++ b/PxGraf/PxGraf.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
 	<TargetFrameworks>net10.0</TargetFrameworks>
@@ -7,7 +7,7 @@
     <AssemblyName>PxGraf</AssemblyName>
     <UserSecretsId>5fefcbdc-e04e-4475-9927-aab412b027ff</UserSecretsId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>4.7.2</VersionPrefix>
+    <VersionPrefix>4.7.3</VersionPrefix>
 	<SpaRoot>..\PxGraf.Frontend</SpaRoot>
 	<Configurations>Debug;Release;Test</Configurations>
   </PropertyGroup>

--- a/PxGraf/Utility/ISqFileInterface.cs
+++ b/PxGraf/Utility/ISqFileInterface.cs
@@ -11,12 +11,12 @@ namespace PxGraf.Utility
         /// <summary>
         /// Returns true if a saved query file with the given sq id exists withing the specified saved query file location.
         /// </summary>
-        public bool SavedQueryExists(string id, string savedQueryDirectory);
+        public Task<bool> SavedQueryExists(string id, string savedQueryDirectory);
 
         /// <summary>
         /// Returns true if an archive query file with the given sq id exists withing the specified archive query file location.
         /// </summary>
-        public bool ArchiveCubeExists(string id, string archiveDirectory);
+        public Task<bool> ArchiveCubeExists(string id, string archiveDirectory);
 
         /// <summary>
         /// Reads serialized SavedQuery object from a file.
@@ -31,8 +31,13 @@ namespace PxGraf.Utility
         public Task<ArchiveCube> ReadArchiveCubeFromFile(string id, string archiveDirectory);
 
         /// <summary>
-        /// Serialize a json serializable object and write it to a file.
+        /// Serialize a json serializable query object and write it to a saved query file.
         /// </summary>
-        public Task SerializeToFile(string fileName, string filePath, object input);
+        public Task SerializeToSqFileAsync(string fileName, string filePath, object input);
+
+        /// <summary>
+        /// Serialize a json serializable query archive object and write it to an archive file.
+        /// </summary>
+        public Task SerializeToArchiveFileAsync(string fileName, string filePath, object input);
     }
 }

--- a/PxGraf/Utility/ISqFileInterface.cs
+++ b/PxGraf/Utility/ISqFileInterface.cs
@@ -9,12 +9,12 @@ namespace PxGraf.Utility
     public interface ISqFileInterface
     {
         /// <summary>
-        /// Returns true if a saved query file with the given sq id exists withing the specified saved query file location.
+        /// Returns true if a saved query file with the given sq id exists within the specified saved query file location.
         /// </summary>
         public Task<bool> SavedQueryExists(string id, string savedQueryDirectory);
 
         /// <summary>
-        /// Returns true if an archive query file with the given sq id exists withing the specified archive query file location.
+        /// Returns true if an archive query file with the given sq id exists within the specified archive query file location.
         /// </summary>
         public Task<bool> ArchiveCubeExists(string id, string archiveDirectory);
 

--- a/PxGraf/Utility/LockByKey.cs
+++ b/PxGraf/Utility/LockByKey.cs
@@ -1,81 +1,87 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace PxGraf.Utility
 {
-    [ExcludeFromCodeCoverage] // Unable to find a good way to test a fifo mutex
     public class LockByKey(IEqualityComparer<string> keyComparer)
     {
-        private sealed class LockInfo {
-            public readonly object mutex;
-            public int threadCounter;
-
-            public LockInfo()
-            {
-                mutex = new object();
-                threadCounter = 0;
-            }
+        private sealed class AsyncLockInfo
+        {
+            public readonly SemaphoreSlim semaphore = new(1, 1);
+            public int refCount;
         }
 
-        private readonly Dictionary<string, LockInfo> locks = new(keyComparer);
+        private readonly Dictionary<string, AsyncLockInfo> asyncLocks = new(keyComparer);
 
-        public void RunLocked(string key, Action action)
+        public async Task RunLockedAsync(string key, Func<Task> action)
         {
-            object mutex = Lock(key);
+            SemaphoreSlim semaphore = AsyncLock(key);
             try
             {
-                lock (mutex)
+                await semaphore.WaitAsync();
+                try
                 {
-                    action();
+                    await action();
+                }
+                finally
+                {
+                    semaphore.Release();
                 }
             }
             finally
             {
-                UnLock(key);
+                AsyncUnLock(key);
             }
         }
 
-        public T RunLocked<T>(string key, Func<T> action)
+        public async Task<T> RunLockedAsync<T>(string key, Func<Task<T>> action)
         {
-            object mutex = Lock(key);
+            SemaphoreSlim semaphore = AsyncLock(key);
             try
             {
-                lock (mutex)
+                await semaphore.WaitAsync();
+                try
                 {
-                    return action();
+                    return await action();
+                }
+                finally
+                {
+                    semaphore.Release();
                 }
             }
             finally
             {
-                UnLock(key);
+                AsyncUnLock(key);
             }
         }
 
-        private object Lock(string key)
+        private SemaphoreSlim AsyncLock(string key)
         {
-            lock (locks)
+            lock (asyncLocks)
             {
-                if (!locks.TryGetValue(key, out LockInfo lockByKey))
+                if (!asyncLocks.TryGetValue(key, out AsyncLockInfo info))
                 {
-                    lockByKey = new ();
-                    locks.Add(key, lockByKey);
+                    info = new AsyncLockInfo();
+                    asyncLocks.Add(key, info);
                 }
 
-                lockByKey.threadCounter++;
-                return lockByKey.mutex;
+                info.refCount++;
+                return info.semaphore;
             }
         }
 
-        private void UnLock(string key)
+        private void AsyncUnLock(string key)
         {
-            lock (locks)
+            lock (asyncLocks)
             {
-                LockInfo lockInfo = locks[key];
-                lockInfo.threadCounter--;
-                if (lockInfo.threadCounter <= 0)
+                AsyncLockInfo info = asyncLocks[key];
+                info.refCount--;
+                if (info.refCount <= 0)
                 {
-                    locks.Remove(key);
+                    info.semaphore.Dispose();
+                    asyncLocks.Remove(key);
                 }
             }
         }

--- a/PxGraf/Utility/SqFileInterface.cs
+++ b/PxGraf/Utility/SqFileInterface.cs
@@ -61,7 +61,7 @@ namespace PxGraf.Utility
         public async Task<SavedQuery> ReadSavedQueryFromFile(string id, string savedQueryDirectory)
         {
             string filePath = savedQueryStorage.CombinePath(savedQueryDirectory, id + ".sq");
-            return await lockScope.RunLocked(
+            return await lockScope.RunLockedAsync(
                 filePath,
                 () => ReadJsonObjectFromFileImpl<SavedQuery>(savedQueryStorage, filePath)
             );
@@ -73,7 +73,7 @@ namespace PxGraf.Utility
         public async Task<ArchiveCube> ReadArchiveCubeFromFile(string id, string archiveDirectory)
         {
             string filePath = archiveStorage.CombinePath(archiveDirectory, id + ".sqa");
-            return await lockScope.RunLocked(
+            return await lockScope.RunLockedAsync(
                 filePath,
                 () => ReadJsonObjectFromFileImpl<ArchiveCube>(archiveStorage, filePath)
             );
@@ -101,9 +101,9 @@ namespace PxGraf.Utility
         public async Task SerializeToSqFileAsync(string fileName, string filePath, object input)
         {
             string fullPath = savedQueryStorage.CombinePath(filePath, fileName);
-            await lockScope.RunLocked(
-                fileName,
-                () => SerializeToFileImplAsync(fullPath, input)
+            await lockScope.RunLockedAsync(
+                fullPath,
+                () => SerializeToFileImplAsync(savedQueryStorage, fullPath, input)
             );
         }
 
@@ -118,16 +118,16 @@ namespace PxGraf.Utility
         public async Task SerializeToArchiveFileAsync(string fileName, string filePath, object input)
         {
             string fullPath = archiveStorage.CombinePath(filePath, fileName);
-            await lockScope.RunLocked(
-                fileName,
-                () => SerializeToFileImplAsync(fullPath, input)
+            await lockScope.RunLockedAsync(
+                fullPath,
+                () => SerializeToFileImplAsync(archiveStorage, fullPath, input)
             );
         }
 
-        private async Task SerializeToFileImplAsync(string fullPath, object input)
+        private static async Task SerializeToFileImplAsync(IStorageProvider storage, string fullPath, object input)
         {
             string json = JsonSerializer.Serialize(input, GlobalJsonConverterOptions.Default);
-            await savedQueryStorage.WriteAllTextAsync(fullPath, json);
+            await storage.WriteAllTextAsync(fullPath, json);
         }
     }
 }

--- a/PxGraf/Utility/SqFileInterface.cs
+++ b/PxGraf/Utility/SqFileInterface.cs
@@ -26,12 +26,12 @@ namespace PxGraf.Utility
         /// <summary>
         /// Returns true if a saved query file with the given sq id exists within the specified saved query file location.
         /// </summary>
-        public bool SavedQueryExists(string id, string savedQueryDirectory)
+        public async Task<bool> SavedQueryExists(string id, string savedQueryDirectory)
         {
             if (InputValidation.ValidateSqIdString(id))
             {
                 string filePath = savedQueryStorage.CombinePath(savedQueryDirectory, id + ".sq");
-                return savedQueryStorage.FileExistsAsync(filePath).GetAwaiter().GetResult();
+                return await savedQueryStorage.FileExistsAsync(filePath);
             }
             else
             {
@@ -42,12 +42,12 @@ namespace PxGraf.Utility
         /// <summary>
         /// Returns true if an archive query file with the given sq id exists within the specified archive query file location.
         /// </summary>
-        public bool ArchiveCubeExists(string id, string archiveDirectory)
+        public async Task<bool> ArchiveCubeExists(string id, string archiveDirectory)
         {
             if (InputValidation.ValidateSqIdString(id))
             {
                 string filePath = archiveStorage.CombinePath(archiveDirectory, id + ".sqa");
-                return archiveStorage.FileExistsAsync(filePath).GetAwaiter().GetResult();
+                return await archiveStorage.FileExistsAsync(filePath);
             }
             else
             {
@@ -91,26 +91,43 @@ namespace PxGraf.Utility
         }
 
         /// <summary>
-        /// Asynchronous function for serializing json serializable objects to a file.
+        /// Asynchronous function for serializing query objects to a file.
         /// This function handles locking the file.
         /// </summary>
         /// <param name="fileName">Name of the file to be created</param>
         /// <param name="filePath">Target file location</param>
         /// <param name="input">This will be serialized to the file</param>
         /// <returns>Serialization task</returns>
-        public async Task SerializeToFile(string fileName, string filePath, object input)
-        {
-            await Task.Factory.StartNew(() =>
-            {
-                lockScope.RunLocked(fileName, () => SerializeToFileImpl(fileName, filePath, input));
-            });
-        }
-
-        private void SerializeToFileImpl(string fileName, string filePath, object input)
+        public async Task SerializeToSqFileAsync(string fileName, string filePath, object input)
         {
             string fullPath = savedQueryStorage.CombinePath(filePath, fileName);
+            await lockScope.RunLocked(
+                fileName,
+                () => SerializeToFileImplAsync(fullPath, input)
+            );
+        }
+
+        /// <summary>
+        /// Asynchronous function for serializing query archive objects to a file.
+        /// This function handles locking the file.
+        /// </summary>
+        /// <param name="fileName">Name of the file to be created</param>
+        /// <param name="filePath">Target file location</param>
+        /// <param name="input">This will be serialized to the file</param>
+        /// <returns>Serialization task</returns>
+        public async Task SerializeToArchiveFileAsync(string fileName, string filePath, object input)
+        {
+            string fullPath = archiveStorage.CombinePath(filePath, fileName);
+            await lockScope.RunLocked(
+                fileName,
+                () => SerializeToFileImplAsync(fullPath, input)
+            );
+        }
+
+        private async Task SerializeToFileImplAsync(string fullPath, object input)
+        {
             string json = JsonSerializer.Serialize(input, GlobalJsonConverterOptions.Default);
-            savedQueryStorage.WriteAllTextAsync(fullPath, json).GetAwaiter().GetResult();
+            await savedQueryStorage.WriteAllTextAsync(fullPath, json);
         }
     }
 }

--- a/UnitTests/ControllerTests/QueryMetaControllerTests/GetQueryMetaTests.cs
+++ b/UnitTests/ControllerTests/QueryMetaControllerTests/GetQueryMetaTests.cs
@@ -67,7 +67,7 @@ namespace UnitTests.ControllerTests.QueryMetaControllerTests
         private void SetupMocksForSuccessfulQuery(SavedQuery savedQuery, List<DimensionParameters> dimParams, bool isArchived = false, ArchiveCube archiveCube = null)
         {
             _sqFileInterface.Setup(fi => fi.SavedQueryExists(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(true);
+                .ReturnsAsync(true);
 
             _sqFileInterface.Setup(fi => fi.ReadSavedQueryFromFile(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(savedQuery);
@@ -80,7 +80,7 @@ namespace UnitTests.ControllerTests.QueryMetaControllerTests
             else
             {
                 _sqFileInterface.Setup(fi => fi.ArchiveCubeExists(It.IsAny<string>(), It.IsAny<string>()))
-                    .Returns(archiveCube != null);
+                    .ReturnsAsync(archiveCube != null);
 
                 if (archiveCube != null)
                 {
@@ -178,8 +178,8 @@ namespace UnitTests.ControllerTests.QueryMetaControllerTests
         {
             // Arrange
             _sqFileInterface.Setup(fi => fi.SavedQueryExists(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(false);
-            
+                .ReturnsAsync(false);
+
             QueryMetaController controller = CreateController();
 
             // Act
@@ -270,8 +270,8 @@ namespace UnitTests.ControllerTests.QueryMetaControllerTests
             SavedQuery sq = TestDataCubeBuilder.BuildTestSavedQuery(dimParams, false, settings);
             
             _sqFileInterface.Setup(fi => fi.SavedQueryExists(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(true);
-            
+                .ReturnsAsync(true);
+
             _sqFileInterface.Setup(fi => fi.ReadSavedQueryFromFile(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(sq);
             

--- a/UnitTests/ControllerTests/SqControllerTests/ArchiveQueryAsyncTests.cs
+++ b/UnitTests/ControllerTests/SqControllerTests/ArchiveQueryAsyncTests.cs
@@ -96,7 +96,10 @@ namespace UnitTests.ControllerTests.SqControllerTests
             mockCachedDatasource.Setup(c => c.GetMatrixCachedAsync(It.IsAny<PxTableReference>(), It.IsAny<IReadOnlyMatrixMetadata>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestMatrix(cubeParams)));
 
-            mockSqFileInterface.Setup(s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+            mockSqFileInterface.Setup(s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+                .Returns(Task.CompletedTask);
+
+            mockSqFileInterface.Setup(s => s.SerializeToArchiveFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ArchiveCube>()))
                 .Returns(Task.CompletedTask);
 
             mockWebhookService.Setup(w => w.TriggerWebhookAsync(It.IsAny<string>(), It.IsAny<SavedQuery>(), It.IsAny<IReadOnlyDictionary<string, Px.Utils.Models.Metadata.MetaProperties.MetaProperty>>()))
@@ -110,7 +113,7 @@ namespace UnitTests.ControllerTests.SqControllerTests
             // Assert
             Assert.That(result.Value, Is.InstanceOf<SaveQueryResponse>());
             mockSqFileInterface.Verify(
-                s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()), Times.Once);
+                s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()), Times.Once);
 
             // Verify audit log was called with the correct parameters
             mockAuditLogService.Verify(
@@ -183,7 +186,10 @@ namespace UnitTests.ControllerTests.SqControllerTests
             mockCachedDatasource.Setup(c => c.GetMatrixCachedAsync(It.IsAny<PxTableReference>(), It.IsAny<IReadOnlyMatrixMetadata>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestMatrix(cubeParams)));
 
-            mockSqFileInterface.Setup(s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+            mockSqFileInterface.Setup(s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+                .Returns(Task.CompletedTask);
+
+            mockSqFileInterface.Setup(s => s.SerializeToArchiveFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ArchiveCube>()))
                 .Returns(Task.CompletedTask);
 
             mockWebhookService.Setup(w => w.TriggerWebhookAsync(It.IsAny<string>(), It.IsAny<SavedQuery>(), It.IsAny<IReadOnlyDictionary<string, Px.Utils.Models.Metadata.MetaProperties.MetaProperty>>()))
@@ -253,7 +259,10 @@ namespace UnitTests.ControllerTests.SqControllerTests
             mockCachedDatasource.Setup(c => c.GetMatrixCachedAsync(It.IsAny<PxTableReference>(), It.IsAny<IReadOnlyMatrixMetadata>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestMatrix(cubeParams)));
 
-            mockSqFileInterface.Setup(s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+            mockSqFileInterface.Setup(s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+                .Returns(Task.CompletedTask);
+
+            mockSqFileInterface.Setup(s => s.SerializeToArchiveFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ArchiveCube>()))
                 .Returns(Task.CompletedTask);
 
             SqController testController = new(mockCachedDatasource.Object, mockSqFileInterface.Object, mockLogger.Object, mockAuditLogService.Object, mockWebhookService.Object);
@@ -319,7 +328,7 @@ namespace UnitTests.ControllerTests.SqControllerTests
             mockCachedDatasource.Setup(c => c.GetMatrixCachedAsync(It.IsAny<PxTableReference>(), It.IsAny<IReadOnlyMatrixMetadata>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestMatrix(cubeParams)));
 
-            mockSqFileInterface.Setup(s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+            mockSqFileInterface.Setup(s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
                 .Returns(Task.CompletedTask);
 
             SqController testController = new(mockCachedDatasource.Object, mockSqFileInterface.Object, mockLogger.Object, mockAuditLogService.Object, mockWebhookService.Object);
@@ -375,7 +384,7 @@ namespace UnitTests.ControllerTests.SqControllerTests
             mockCachedDatasource.Setup(c => c.GetMatrixCachedAsync(It.IsAny<PxTableReference>(), It.IsAny<IReadOnlyMatrixMetadata>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestMatrix(cubeParams)));
 
-            mockSqFileInterface.Setup(s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+            mockSqFileInterface.Setup(s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
                 .Returns(Task.CompletedTask);
 
             SqController testController = new(mockCachedDatasource.Object, mockSqFileInterface.Object, mockLogger.Object, mockAuditLogService.Object, mockWebhookService.Object);
@@ -386,7 +395,7 @@ namespace UnitTests.ControllerTests.SqControllerTests
             // Assert
             Assert.That(result.Result, Is.InstanceOf<BadRequestResult>());
             mockSqFileInterface.Verify(
-                s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()), Times.Never);
+                s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()), Times.Never);
 
             // Verify audit log was called with invalid request
             mockAuditLogService.Verify(
@@ -432,7 +441,7 @@ namespace UnitTests.ControllerTests.SqControllerTests
             mockCachedDatasource.Setup(c => c.GetMatrixCachedAsync(It.IsAny<PxTableReference>(), It.IsAny<IReadOnlyMatrixMetadata>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestMatrix(cubeParams)));
 
-            mockSqFileInterface.Setup(s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+            mockSqFileInterface.Setup(s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
                 .Returns(Task.CompletedTask);
 
             SqController testController = new(mockCachedDatasource.Object, mockSqFileInterface.Object, mockLogger.Object, mockAuditLogService.Object, mockWebhookService.Object);
@@ -443,7 +452,7 @@ namespace UnitTests.ControllerTests.SqControllerTests
             // Assert
             Assert.That(result.Result, Is.InstanceOf<BadRequestResult>());
             mockSqFileInterface.Verify(
-                s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()), Times.Never);
+                s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()), Times.Never);
 
             // Verify audit log was called with invalid request
             mockAuditLogService.Verify(

--- a/UnitTests/ControllerTests/SqControllerTests/GetSavedQueryAsyncTests.cs
+++ b/UnitTests/ControllerTests/SqControllerTests/GetSavedQueryAsyncTests.cs
@@ -75,12 +75,12 @@ namespace UnitTests.ControllerTests.SqControllerTests
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestMatrix(cubeParams)));
 
             mockSqFileInterface.Setup(x => x.SavedQueryExists(It.Is<string>(s => s == testQueryId), It.IsAny<string>()))
-                .Returns(true);
+                .ReturnsAsync(true);
             mockSqFileInterface.Setup(x => x.ReadSavedQueryFromFile(It.Is<string>(s => s == testQueryId), It.IsAny<string>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestSavedQuery(cubeParams, false, new LineChartVisualizationSettings(null, false, null))));
 
             SqController metaController = new(mockCachedDatasource.Object, mockSqFileInterface.Object, mockLogger.Object, mockAuditLogService.Object, mockWebhookService.Object);
-            
+
             // Act
             ActionResult<SaveQueryParams> result = await metaController.GetSavedQueryAsync(testQueryId);
 
@@ -129,7 +129,7 @@ namespace UnitTests.ControllerTests.SqControllerTests
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestMatrix(cubeParams)));
 
             mockSqFileInterface.Setup(x => x.SavedQueryExists(It.Is<string>(s => s == testQueryId), It.IsAny<string>()))
-                .Returns(true);
+                .ReturnsAsync(true);
             mockSqFileInterface.Setup(x => x.ReadSavedQueryFromFile(It.Is<string>(s => s == testQueryId), It.IsAny<string>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestSavedQuery(cubeParams, false, new HorizontalBarChartVisualizationSettings(null))));
 
@@ -162,7 +162,7 @@ namespace UnitTests.ControllerTests.SqControllerTests
             string testQueryId = "aaa-bbb-111-222-333";
 
             mockSqFileInterface.Setup(x => x.SavedQueryExists(It.Is<string>(s => s == testQueryId), It.IsAny<string>()))
-                .Returns(false);
+                .ReturnsAsync(false);
 
             SqController metaController = new(mockCachedDatasource.Object, mockSqFileInterface.Object, mockLogger.Object, mockAuditLogService.Object, mockWebhookService.Object);
             
@@ -206,7 +206,7 @@ namespace UnitTests.ControllerTests.SqControllerTests
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestMatrix(metaParams)));
 
             mockSqFileInterface.Setup(x => x.SavedQueryExists(It.Is<string>(s => s == testQueryId), It.IsAny<string>()))
-                .Returns(true);
+                .ReturnsAsync(true);
             mockSqFileInterface.Setup(x => x.ReadSavedQueryFromFile(It.Is<string>(s => s == testQueryId), It.IsAny<string>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestSavedQuery(metaParams, false, new HorizontalBarChartVisualizationSettings(null))));
 

--- a/UnitTests/ControllerTests/SqControllerTests/ReArchiveActionTests.cs
+++ b/UnitTests/ControllerTests/SqControllerTests/ReArchiveActionTests.cs
@@ -61,11 +61,14 @@ namespace UnitTests.ControllerTests.SqControllerTests
             _mockCachedDatasource.Setup(c => c.GetMatrixCachedAsync(It.IsAny<PxTableReference>(), It.IsAny<IReadOnlyMatrixMetadata>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestMatrix(cubeParams)));
 
-            _mockSqFileInterface.Setup(s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+            _mockSqFileInterface.Setup(s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+                .Returns(Task.CompletedTask);
+
+            _mockSqFileInterface.Setup(s => s.SerializeToArchiveFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ArchiveCube>()))
                 .Returns(Task.CompletedTask);
 
             _mockSqFileInterface.Setup(s => s.SavedQueryExists(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(cubeParams.Count > 0);
+                .ReturnsAsync(cubeParams.Count > 0);
 
             _mockSqFileInterface.Setup(s => s.ReadSavedQueryFromFile(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestSavedQuery(cubeParams, false, new LineChartVisualizationSettings(null, false, null))));

--- a/UnitTests/ControllerTests/SqControllerTests/SaveQueryAsyncTest.cs
+++ b/UnitTests/ControllerTests/SqControllerTests/SaveQueryAsyncTest.cs
@@ -80,7 +80,7 @@ namespace UnitTests.ControllerTests.SqControllerTests
             mockCachedDatasource.Setup(c => c.GetMatrixCachedAsync(It.IsAny<PxTableReference>(), It.IsAny<IReadOnlyMatrixMetadata>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestMatrix(cubeParams)));
 
-            mockSqFileInterface.Setup(s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+            mockSqFileInterface.Setup(s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
                 .Returns(Task.CompletedTask);
 
             mockWebhookService.Setup(s => s.TriggerWebhookAsync(It.IsAny<string>(), It.IsAny<SavedQuery>(), It.IsAny<IReadOnlyDictionary<string, MetaProperty>>()))
@@ -103,7 +103,7 @@ namespace UnitTests.ControllerTests.SqControllerTests
             ActionResult<SaveQueryResponse> actionResult = await testController.SaveQueryAsync(testInput);
             Assert.That(actionResult.Value, Is.InstanceOf<SaveQueryResponse>());
             mockSqFileInterface.Verify(
-                s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()), Times.Once);
+                s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()), Times.Once);
             mockWebhookService.Verify(
                 w => w.TriggerWebhookAsync(It.IsAny<string>(), It.IsAny<SavedQuery>(), It.IsAny<IReadOnlyDictionary<string, MetaProperty>>()),
                 Times.Once);
@@ -153,7 +153,7 @@ namespace UnitTests.ControllerTests.SqControllerTests
             mockCachedDatasource.Setup(c => c.GetMatrixCachedAsync(It.IsAny<PxTableReference>(), It.IsAny<IReadOnlyMatrixMetadata>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestMatrix(cubeParams)));
 
-            mockSqFileInterface.Setup(s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+            mockSqFileInterface.Setup(s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
                 .Returns(Task.CompletedTask);
 
             mockWebhookService.Setup(w => w.TriggerWebhookAsync(It.IsAny<string>(), It.IsAny<SavedQuery>(), It.IsAny<IReadOnlyDictionary<string, Px.Utils.Models.Metadata.MetaProperties.MetaProperty>>()))
@@ -219,7 +219,7 @@ namespace UnitTests.ControllerTests.SqControllerTests
             mockCachedDatasource.Setup(c => c.GetMatrixCachedAsync(It.IsAny<PxTableReference>(), It.IsAny<IReadOnlyMatrixMetadata>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestMatrix(cubeParams)));
 
-            mockSqFileInterface.Setup(s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+            mockSqFileInterface.Setup(s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
                 .Returns(Task.CompletedTask);
 
             SaveQueryParams testInput = new()
@@ -291,7 +291,7 @@ namespace UnitTests.ControllerTests.SqControllerTests
             mockCachedDatasource.Setup(c => c.GetMatrixCachedAsync(It.IsAny<PxTableReference>(), It.IsAny<IReadOnlyMatrixMetadata>()))
                 .Returns(Task.Run(() => TestDataCubeBuilder.BuildTestMatrix(cubeParams)));
 
-            mockSqFileInterface.Setup(s => s.SerializeToFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
+            mockSqFileInterface.Setup(s => s.SerializeToSqFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SavedQuery>()))
                 .Returns(Task.CompletedTask);
 
             SaveQueryParams testInput = new()

--- a/UnitTests/ControllerTests/VisualizationControllerTests/GetVisualizationTests.cs
+++ b/UnitTests/ControllerTests/VisualizationControllerTests/GetVisualizationTests.cs
@@ -88,13 +88,13 @@ namespace UnitTests.ControllerTests.VisualizationControllerTests
                 });
 
             _mockSqFileInterface.Setup(x => x.SavedQueryExists(It.Is<string>(id => id == testQueryId), It.IsAny<string>()))
-                .Returns(savedQueryFound);
-            
+                .ReturnsAsync(savedQueryFound);
+
             _mockSqFileInterface.Setup(x => x.ReadSavedQueryFromFile(It.Is<string>(id => id == testQueryId), It.IsAny<string>()))
                 .ReturnsAsync(() => TestDataCubeBuilder.BuildTestSavedQuery(cubeParams, archived, new LineChartVisualizationSettings(null, false, null)));
-            
+
             _mockSqFileInterface.Setup(x => x.ArchiveCubeExists(It.Is<string>(id => id == testQueryId), It.IsAny<string>()))
-                .Returns(true);
+                .ReturnsAsync(true);
             
             _mockSqFileInterface.Setup(x => x.ReadArchiveCubeFromFile(It.Is<string>(id => id == testQueryId), It.IsAny<string>()))
                 .ReturnsAsync(() => TestDataCubeBuilder.BuildTestArchiveCube(metaParams));

--- a/UnitTests/TestQueryMetaControllerBuilder.cs
+++ b/UnitTests/TestQueryMetaControllerBuilder.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using Microsoft.Extensions.Logging;
 using Moq;
 using PxGraf.Controllers;
@@ -22,7 +22,7 @@ namespace UnitTests
             Mock<IAuditLogService> auditLogService = new();
 
             sqFileInterface.Setup(fi => fi.SavedQueryExists(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns((string sq, string archivePath) =>
+                .ReturnsAsync((string sq, string archivePath) =>
                 {
                     return savedQueries.ContainsKey($"{archiveRoot}/{sq}");
                 });
@@ -41,7 +41,7 @@ namespace UnitTests
                 });
 
             sqFileInterface.Setup(fi => fi.ArchiveCubeExists(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns((string id, string archivePath) =>
+                .ReturnsAsync((string id, string archivePath) =>
                 {
                     if (archiveCubes == null) return false;
                     return archiveCubes.ContainsKey($"{archiveRoot}/{id}");

--- a/UnitTests/TestVisualizationControllerBuilder.cs
+++ b/UnitTests/TestVisualizationControllerBuilder.cs
@@ -1,17 +1,14 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Px.Utils.Models.Metadata;
-using Px.Utils.Models.Metadata.Enums;
 using PxGraf.Controllers;
 using PxGraf.Datasource;
 using PxGraf.Datasource.Cache;
 using PxGraf.Models.Queries;
 using PxGraf.Models.Responses;
-using PxGraf.Models.SavedQueries;
 using PxGraf.Services;
-using PxGraf.Settings;
 using PxGraf.Utility;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -49,13 +46,13 @@ namespace UnitTests
                 });
 
             sqFileInterface.Setup(x => x.SavedQueryExists(It.Is<string>(s => s == testQueryId), It.IsAny<string>()))
-                .Returns(savedQueryFound);
-                
+                .ReturnsAsync(savedQueryFound);
+
             sqFileInterface.Setup(x => x.ReadSavedQueryFromFile(It.Is<string>(s => s == testQueryId), It.IsAny<string>()))
                 .ReturnsAsync(() => TestDataCubeBuilder.BuildTestSavedQuery(cubeParams, archived, new LineChartVisualizationSettings(null, false, null)));
-                
+
             sqFileInterface.Setup(x => x.ArchiveCubeExists(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(true);
+                .ReturnsAsync(true);
                 
             sqFileInterface.Setup(x => x.ReadArchiveCubeFromFile(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(() => TestDataCubeBuilder.BuildTestArchiveCube(metaParams));

--- a/UnitTests/UtilityFunctionsTests/LockByKeyTests.cs
+++ b/UnitTests/UtilityFunctionsTests/LockByKeyTests.cs
@@ -1,0 +1,286 @@
+using NUnit.Framework;
+using PxGraf.Utility;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UnitTests.UtilityFunctionsTests
+{
+    internal class LockByKeyTests
+    {
+        private LockByKey _lockByKey;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _lockByKey = new LockByKey(StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Test]
+        public async Task RunLockedAsync_ExecutesAction()
+        {
+            // Arrange
+            bool executed = false;
+
+            // Act
+            await _lockByKey.RunLockedAsync("key", () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            });
+
+            // Assert
+            Assert.That(executed, Is.True);
+        }
+
+        [Test]
+        public async Task RunLockedAsyncT_ReturnsValue()
+        {
+            // Act
+            int result = await _lockByKey.RunLockedAsync("key", () => Task.FromResult(42));
+
+            // Assert
+            Assert.That(result, Is.EqualTo(42));
+        }
+
+        [Test]
+        public async Task RunLockedAsync_PropagatesException()
+        {
+            // Act & Assert
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await _lockByKey.RunLockedAsync("key", () =>
+                    throw new InvalidOperationException("test"));
+            });
+
+            // Verify the lock is released and the key can be reused
+            bool executed = false;
+            await _lockByKey.RunLockedAsync("key", () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            });
+            Assert.That(executed, Is.True);
+        }
+
+        [Test]
+        public async Task RunLockedAsyncT_PropagatesException()
+        {
+            // Act & Assert
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await _lockByKey.RunLockedAsync<int>("key", () =>
+                    throw new InvalidOperationException("test"));
+            });
+
+            // Verify the lock is released and the key can be reused
+            int result = await _lockByKey.RunLockedAsync("key", () => Task.FromResult(99));
+            Assert.That(result, Is.EqualTo(99));
+        }
+
+        [Test]
+        public async Task RunLockedAsync_SameKey_SerializesExecution()
+        {
+            // Arrange
+            int concurrentCount = 0;
+            int maxConcurrentCount = 0;
+            List<int> executionOrder = [];
+
+            async Task Action(int id)
+            {
+                int current = Interlocked.Increment(ref concurrentCount);
+                InterlockedMax(ref maxConcurrentCount, current);
+                executionOrder.Add(id);
+                await Task.Delay(50);
+                Interlocked.Decrement(ref concurrentCount);
+            }
+
+            // Act
+            Task task1 = _lockByKey.RunLockedAsync("shared", () => Action(1));
+            Task task2 = _lockByKey.RunLockedAsync("shared", () => Action(2));
+            Task task3 = _lockByKey.RunLockedAsync("shared", () => Action(3));
+            await Task.WhenAll(task1, task2, task3);
+
+            // Assert
+            Assert.That(maxConcurrentCount, Is.EqualTo(1), "Only one action should run at a time for the same key");
+            Assert.That(executionOrder, Has.Count.EqualTo(3));
+        }
+
+        [Test]
+        public async Task RunLockedAsync_DifferentKeys_AllowsConcurrentExecution()
+        {
+            // Arrange
+            int concurrentCount = 0;
+            int maxConcurrentCount = 0;
+            TaskCompletionSource allStarted = new();
+            int startedCount = 0;
+            const int taskCount = 3;
+
+            async Task Action()
+            {
+                int current = Interlocked.Increment(ref concurrentCount);
+                InterlockedMax(ref maxConcurrentCount, current);
+
+                if (Interlocked.Increment(ref startedCount) == taskCount)
+                {
+                    allStarted.SetResult();
+                }
+
+                await allStarted.Task;
+                Interlocked.Decrement(ref concurrentCount);
+            }
+
+            // Act
+            Task task1 = _lockByKey.RunLockedAsync("key-a", Action);
+            Task task2 = _lockByKey.RunLockedAsync("key-b", Action);
+            Task task3 = _lockByKey.RunLockedAsync("key-c", Action);
+            await Task.WhenAll(task1, task2, task3);
+
+            // Assert
+            Assert.That(maxConcurrentCount, Is.EqualTo(taskCount), "Different keys should allow concurrent execution");
+        }
+
+        [Test]
+        public async Task RunLockedAsync_CaseInsensitiveKeys_Serializes()
+        {
+            // Arrange
+            int concurrentCount = 0;
+            int maxConcurrentCount = 0;
+
+            async Task Action()
+            {
+                int current = Interlocked.Increment(ref concurrentCount);
+                InterlockedMax(ref maxConcurrentCount, current);
+                await Task.Delay(50);
+                Interlocked.Decrement(ref concurrentCount);
+            }
+
+            // Act
+            Task task1 = _lockByKey.RunLockedAsync("MyKey", Action);
+            Task task2 = _lockByKey.RunLockedAsync("mykey", Action);
+            Task task3 = _lockByKey.RunLockedAsync("MYKEY", Action);
+            await Task.WhenAll(task1, task2, task3);
+
+            // Assert
+            Assert.That(maxConcurrentCount, Is.EqualTo(1), "Case-insensitive keys should serialize");
+        }
+
+        [Test]
+        public async Task RunLockedAsync_CaseSensitiveComparer_AllowsConcurrentForDifferentCase()
+        {
+            // Arrange
+            LockByKey caseSensitiveLock = new(StringComparer.Ordinal);
+            int concurrentCount = 0;
+            int maxConcurrentCount = 0;
+            TaskCompletionSource allStarted = new();
+            int startedCount = 0;
+
+            async Task Action()
+            {
+                int current = Interlocked.Increment(ref concurrentCount);
+                InterlockedMax(ref maxConcurrentCount, current);
+
+                if (Interlocked.Increment(ref startedCount) == 2)
+                {
+                    allStarted.SetResult();
+                }
+
+                await allStarted.Task;
+                Interlocked.Decrement(ref concurrentCount);
+            }
+
+            // Act
+            Task task1 = caseSensitiveLock.RunLockedAsync("Key", Action);
+            Task task2 = caseSensitiveLock.RunLockedAsync("key", Action);
+            await Task.WhenAll(task1, task2);
+
+            // Assert
+            Assert.That(maxConcurrentCount, Is.EqualTo(2), "Case-sensitive comparer should treat different cases as different keys");
+        }
+
+        [Test]
+        public async Task RunLockedAsync_KeyIsReusableAfterCompletion()
+        {
+            // Arrange & Act
+            int callCount = 0;
+            for (int i = 0; i < 5; i++)
+            {
+                await _lockByKey.RunLockedAsync("reusable", () =>
+                {
+                    callCount++;
+                    return Task.CompletedTask;
+                });
+            }
+
+            // Assert
+            Assert.That(callCount, Is.EqualTo(5));
+        }
+
+        [Test]
+        public async Task RunLockedAsync_KeyIsReusableAfterException()
+        {
+            // Arrange
+            try
+            {
+                await _lockByKey.RunLockedAsync("failkey", () =>
+                    throw new InvalidOperationException());
+            }
+            catch (InvalidOperationException)
+            {
+                // Expected
+            }
+
+            // Act - key should be reusable
+            bool executed = false;
+            await _lockByKey.RunLockedAsync("failkey", () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            });
+
+            // Assert
+            Assert.That(executed, Is.True);
+        }
+
+        [Test]
+        public async Task RunLockedAsyncT_SameKey_SerializesAndReturnsCorrectValues()
+        {
+            // Arrange
+            int concurrentCount = 0;
+            int maxConcurrentCount = 0;
+
+            async Task<int> Action(int value)
+            {
+                int current = Interlocked.Increment(ref concurrentCount);
+                InterlockedMax(ref maxConcurrentCount, current);
+                await Task.Delay(50);
+                Interlocked.Decrement(ref concurrentCount);
+                return value * 2;
+            }
+
+            // Act
+            Task<int> task1 = _lockByKey.RunLockedAsync("key", () => Action(1));
+            Task<int> task2 = _lockByKey.RunLockedAsync("key", () => Action(2));
+            Task<int> task3 = _lockByKey.RunLockedAsync("key", () => Action(3));
+            await Task.WhenAll(task1, task2, task3);
+
+            // Assert
+            Assert.That(maxConcurrentCount, Is.EqualTo(1));
+            Assert.That(task1.Result, Is.EqualTo(2));
+            Assert.That(task2.Result, Is.EqualTo(4));
+            Assert.That(task3.Result, Is.EqualTo(6));
+        }
+
+        private static void InterlockedMax(ref int location, int value)
+        {
+            int current;
+            do
+            {
+                current = Volatile.Read(ref location);
+                if (value <= current) return;
+            }
+            while (Interlocked.CompareExchange(ref location, value, current) != current);
+        }
+    }
+}


### PR DESCRIPTION
Converted file existence checks to async methods and split serialization into async methods for saved queries and archives. Updated controllers, tests, and test builders to use new async signatures. Improves performance and clarifies file operation interfaces.