### PR TITLE
[Fix] Resolve 16 bugs across frontend application

### DIFF
--- a/PxGraf.Frontend/index.html
+++ b/PxGraf.Frontend/index.html
@@ -10,7 +10,7 @@
       name="description"
       content="PxGraf"
     />
-    <link rel="apple-touch-icon" href="/logo192.png" />
+    <link rel="apple-touch-icon" href="/favicon.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -19,18 +19,8 @@
     <title>PxGraf</title>
   </head>
   <body>
-      <script type="module" src="/src/index.tsx"></script>
       <noscript>You need to enable JavaScript to run this app.</noscript>
       <div id="root"></div>
-      <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
+      <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/PxGraf.Frontend/package-lock.json
+++ b/PxGraf.Frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pxgraf",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pxgraf",
-      "version": "2.5.9",
+      "version": "2.5.10",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/PxGraf.Frontend/package.json
+++ b/PxGraf.Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxgraf",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/PxGraf.Frontend/src/api/client.ts
+++ b/PxGraf.Frontend/src/api/client.ts
@@ -42,12 +42,8 @@ export class ApiClientV2 {
     async getAsync(url: string, getParams?: { [key: string]: string }) {
         let getParamPart = '';
         if (getParams) {
-            getParamPart = '?';
-            Object.keys(getParams).forEach((key, index) => {
-                getParamPart += key + '=';
-                getParamPart += getParams[key];
-                if (index + 1 <= Object.keys(getParams).length) getParamPart += '&';
-            });
+            const params = new URLSearchParams(getParams);
+            getParamPart = '?' + params.toString();
         }
         const response = await fetch(this.BASE_URL_V2 + url + getParamPart);
 

--- a/PxGraf.Frontend/src/components/ChartTypeRejectionReasons/ChartTypeRejectionReasons.tsx
+++ b/PxGraf.Frontend/src/components/ChartTypeRejectionReasons/ChartTypeRejectionReasons.tsx
@@ -17,6 +17,10 @@ export const ChartTypeRejectionReasons: React.FC<IChartTypeRejectionReasonsProps
     const { language } = React.useContext(UiLanguageContext);
     const [open, setOpen] = React.useState(false);
 
+    if (!rejectionReasons) {
+        return <></>;
+    }
+
     const rejectionReasonElements: React.ReactNode[] = Object.keys(rejectionReasons).map(key => {
         return (
             <div key={key}>
@@ -29,9 +33,6 @@ export const ChartTypeRejectionReasons: React.FC<IChartTypeRejectionReasonsProps
             </div>
         );
     });
-    if (!rejectionReasons) {
-        return <></>;
-    }
     return (
         <>
             <Button aria-haspopup={true} aria-controls='rejection-dialog' variant={'outlined'} startIcon={<QuestionMarkIcon />} onClick={() => setOpen(true)}>{t("rejectionDialog.buttonText")}</Button>

--- a/PxGraf.Frontend/src/components/DirectoryInfo/DirectoryInfo.test.tsx
+++ b/PxGraf.Frontend/src/components/DirectoryInfo/DirectoryInfo.test.tsx
@@ -52,7 +52,7 @@ describe('Rendering test', () => {
 
 describe('Assertion tests', () => {
     it('should contain a specific link with a specific text', () => {
-        const expectedHref = '/table-list/a/s/d/1/2/3/foo-group/';
+        const expectedHref = '/table-list/asd123/foo-group/';
         render(<MemoryRouter><DirectoryInfo path={mockPath} item={mockItem} /></MemoryRouter>);
         expect(screen.getByText(mockItem.name[language])).toBeInTheDocument();
         expect(screen.getByRole('link').getAttribute('href')).toEqual(expectedHref);

--- a/PxGraf.Frontend/src/components/DirectoryInfo/DirectoryInfo.tsx
+++ b/PxGraf.Frontend/src/components/DirectoryInfo/DirectoryInfo.tsx
@@ -15,7 +15,7 @@ export const DirectoryInfo: React.FC<IDirectoryInfoProps> = ({ path, item }) => 
     const { language } = React.useContext(UiLanguageContext);
     const displayLanguage = item.languages.includes(language) ? language : item.languages[0];
 
-    const currentPath = [...path, item.code];
+    const currentPath = [path, item.code];
     return (
         <>
             <ListItemButton id="mainContent" component={Link} to={urls.tableList(currentPath)}>

--- a/PxGraf.Frontend/src/components/DirectoryInfo/__snapshots__/DirectoryInfo.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/DirectoryInfo/__snapshots__/DirectoryInfo.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Rendering test renders correctly 1`] = `
   <a
     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-4bx69l-MuiButtonBase-root-MuiListItemButton-root"
     data-discover="true"
-    href="/table-list/a/s/d/1/2/3/foo-group/"
+    href="/table-list/asd123/foo-group/"
     id="mainContent"
     tabindex="0"
   >

--- a/PxGraf.Frontend/src/components/MetaEditor/BasicDimensionEditor.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/BasicDimensionEditor.tsx
@@ -54,7 +54,7 @@ export const BasicDimensionEditor: React.FC<IBasicDimensionEditor> = ({ dimensio
                         label={t("editMetadata.valueName") + ": " + value.name[uiContentLanguage]}
                         key={value.code}
                         defaultValue={value.name[language]}
-                        editValue={dimensionEdits?.valueEdits[value.code]?.nameEdit?.[language]}
+                        editValue={dimensionEdits?.valueEdits?.[value.code]?.nameEdit?.[language]}
                         onChange={newValue => handleChange(newValue, value.code)}
                     />
                 );

--- a/PxGraf.Frontend/src/components/SaveResultDialog/SuccessDialogContent.tsx
+++ b/PxGraf.Frontend/src/components/SaveResultDialog/SuccessDialogContent.tsx
@@ -43,7 +43,7 @@ export const SuccessDialogContent: React.FC<ISuccessDialogContentProps> = ({
                 t("saveResultDialog.publicationUnpublished");
         }
 
-        return publicationStatus === EQueryPublicationStatus.Failed ? ("error.webhookResponseError") : t("saveResultDialog.webhookResponseSuccess");
+        return publicationStatus === EQueryPublicationStatus.Failed ? t("error.webhookResponseError") : t("saveResultDialog.webhookResponseSuccess");
     };
 
     const getPublicationAlertSeverity = () => {

--- a/PxGraf.Frontend/src/components/SaveResultDialog/__snapshots__/SuccessDialogContent.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/SaveResultDialog/__snapshots__/SuccessDialogContent.test.tsx.snap
@@ -314,7 +314,7 @@ exports[`Rendering test renders correctly without webhook message (failed) 1`] =
         <div
           class="MuiAlert-message css-zioonp-MuiAlert-message"
         >
-          error.webhookResponseError
+          Webhook response error
         </div>
       </div>
     </div>

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/MultiselectableSelector.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/MultiselectableSelector.tsx
@@ -22,7 +22,7 @@ export const MultiselectableSelector: React.FC<IMultiselectableSelectorProps> = 
                 sx={{ minWidth: 210 }}
                 labelId="multiselectable-selector-label"
                 id="multiselectable-selector"
-                label={"Monivalitaselausmuuttuja"}
+                label={t("chartSettings.multiSelectVariable")}
                 value={visualizationSettings.multiselectableVariableCode ?? "noMultiselectable"}
                 defaultValue={"noMultiselectable"}
                 onChange={(event) => setVisualizationSettingsUserInput({

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/MultiselectableSelector.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/MultiselectableSelector.tsx
@@ -27,7 +27,7 @@ export const MultiselectableSelector: React.FC<IMultiselectableSelectorProps> = 
                 defaultValue={"noMultiselectable"}
                 onChange={(event) => setVisualizationSettingsUserInput({
                     ...visualizationSettings,
-                    multiselectableVariableCode: event.target.value !== "noMultiselectable" ? event.target.value : null
+                    multiselectableVariableCode: event.target.value === "noMultiselectable" ? null : event.target.value
                 })}
             >
                 <MenuItem value={"noMultiselectable"}>{t("chartSettings.noMultiselectable")}</MenuItem>

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/TablePivotSettings.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/TablePivotSettings.tsx
@@ -52,14 +52,14 @@ export const TablePivotSettings: React.FC<ITableSettingsProps> = ({ visualizatio
 
     const downHandler = () => {
         if (selected == null) return;
-        if (visualizationSettings.columnVariableCodes.includes(selected) && visualizationSettings.columnVariableCodes[visualizationSettings.columnVariableCodes.length - 1] !== selected) {
+        if (visualizationSettings.columnVariableCodes.includes(selected) && visualizationSettings.columnVariableCodes.at(-1) !== selected) {
             const dimsCopy = [...visualizationSettings.columnVariableCodes];
             const i = dimsCopy.indexOf(selected);
             dimsCopy[i] = dimsCopy[i + 1];
             dimsCopy[i + 1] = selected;
             setVisualizationSettingsUserInput({ ...visualizationSettings, columnVariableCodes: dimsCopy });
         }
-        else if (visualizationSettings.rowVariableCodes.includes(selected) && visualizationSettings.rowVariableCodes[visualizationSettings.rowVariableCodes.length - 1] !== selected) {
+        else if (visualizationSettings.rowVariableCodes.includes(selected) && visualizationSettings.rowVariableCodes.at(-1) !== selected) {
             const dimsCopy = [...visualizationSettings.rowVariableCodes];
             const i = dimsCopy.indexOf(selected);
             dimsCopy[i] = dimsCopy[i + 1];

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/TablePivotSettings.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/TablePivotSettings.tsx
@@ -87,7 +87,7 @@ export const TablePivotSettings: React.FC<ITableSettingsProps> = ({ visualizatio
         const multiValueDimensionCodes = codes
             .map(c => dimensions.find(v => v.code === c))
             .filter(v => dimensions.filter(v => query[v.code].valueFilter.type === 'from' || query[v.code].valueFilter.type === 'all')?.includes(v) || v.values.length > 1)
-            .filter(v => !selectableDimensions?.includes(v) || v.Code === visualizationSettings.multiselectableVariableCode);
+            .filter(v => !selectableDimensions?.includes(v) || v.code === visualizationSettings.multiselectableVariableCode);
         return multiValueDimensionCodes;
     }
 

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/__snapshots__/MultiselectableSelector.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/__snapshots__/MultiselectableSelector.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`Rendering test renders correctly 1`] = `
           class="css-ex8a5f-MuiNotchedOutlined-root"
         >
           <span>
-            Monivalitaselausmuuttuja
+            chartSettings.multiSelectVariable
           </span>
         </legend>
       </fieldset>

--- a/PxGraf.Frontend/src/hooks/__tests__/useReplaceQueryParams.test.tsx
+++ b/PxGraf.Frontend/src/hooks/__tests__/useReplaceQueryParams.test.tsx
@@ -2,37 +2,40 @@ import { renderHook } from '@testing-library/react';
 import useReplaceQueryParams from 'hooks/useReplaceQueryParams';
 import * as useHierarchyParams from 'hooks/useHierarchyParams';
 import * as navigationContext from 'contexts/navigationContext'
-import * as Router from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+
+const mockNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => {
     return {
         __esModule: true,
         ...jest.requireActual('react-router-dom'),
+        useNavigate: jest.fn(() => mockNavigate),
+        useLocation: jest.fn(() => ({ pathname: '/', search: '', hash: '', state: null, key: 'default' })),
     }
 });
 
 const useParams = jest.spyOn(useHierarchyParams, 'default');
 const useNavigationContext = jest.spyOn(navigationContext, 'useNavigationContext');
-const useNavigate = jest.spyOn(Router, 'useNavigate');
 
 describe('useReplaceQueryParams hook', () => {
+    beforeEach(() => {
+        mockNavigate.mockClear();
+    });
+
     it('should replace query params and reload if context not matching current params', () => {
         useParams.mockReturnValueOnce(['testDb', 'testStat', 'testTable']);
         useNavigationContext.mockReturnValueOnce({
             tablePath: ['testDb2', 'testStat2', 'testTable2'],
             setTablePath: jest.fn(),
         });
-        const mockNavigate = jest.fn();
-        useNavigate.mockReturnValueOnce(mockNavigate);
 
         renderHook(() => useReplaceQueryParams('/'));
 
-        expect(mockNavigate).toHaveBeenNthCalledWith(1, {
+        expect(mockNavigate).toHaveBeenCalledWith({
             pathname: '/',
             search: '?tablePath=testDb2,testStat2,testTable2',
         }, { replace: true});
-
-        expect(mockNavigate).toHaveBeenNthCalledWith(2, 0);
     });
 
     it('should replace query params and reload if current params are empty but context is not', () => {
@@ -41,17 +44,13 @@ describe('useReplaceQueryParams hook', () => {
             tablePath: ['testDb', 'testStat', 'testTable'],
             setTablePath: jest.fn(),
         });
-        const mockNavigate = jest.fn();
-        useNavigate.mockReturnValueOnce(mockNavigate);
 
         renderHook(() => useReplaceQueryParams('/my-route'));
 
-        expect(mockNavigate).toHaveBeenNthCalledWith(1, {
+        expect(mockNavigate).toHaveBeenCalledWith({
             pathname: '/my-route',
             search: '?tablePath=testDb,testStat,testTable',
         }, { replace: true});
-
-        expect(mockNavigate).toHaveBeenNthCalledWith(2, 0);
     });
 
     it('should not call navigate if all current params match context', () => {
@@ -60,8 +59,6 @@ describe('useReplaceQueryParams hook', () => {
             tablePath: ['testDb', 'testStat', 'testTable'],
             setTablePath: jest.fn(),
         });
-        const mockNavigate = jest.fn();
-        useNavigate.mockReturnValueOnce(mockNavigate);
 
         renderHook(() => useReplaceQueryParams('/'));
 
@@ -74,8 +71,6 @@ describe('useReplaceQueryParams hook', () => {
             tablePath: [],
             setTablePath: jest.fn(),
         });
-        const mockNavigate = jest.fn();
-        useNavigate.mockReturnValueOnce(mockNavigate);
 
         renderHook(() => useReplaceQueryParams('/'));
 
@@ -88,8 +83,6 @@ describe('useReplaceQueryParams hook', () => {
             tablePath: null,
             setTablePath: jest.fn(),
         });
-        const mockNavigate = jest.fn();
-        useNavigate.mockReturnValueOnce(mockNavigate);
 
         renderHook(() => useReplaceQueryParams('/'));
 

--- a/PxGraf.Frontend/src/hooks/__tests__/useReplaceQueryParams.test.tsx
+++ b/PxGraf.Frontend/src/hooks/__tests__/useReplaceQueryParams.test.tsx
@@ -2,7 +2,6 @@ import { renderHook } from '@testing-library/react';
 import useReplaceQueryParams from 'hooks/useReplaceQueryParams';
 import * as useHierarchyParams from 'hooks/useHierarchyParams';
 import * as navigationContext from 'contexts/navigationContext'
-import { useNavigate } from 'react-router-dom';
 
 const mockNavigate = jest.fn();
 

--- a/PxGraf.Frontend/src/hooks/__tests__/useReplaceQueryParams.test.tsx
+++ b/PxGraf.Frontend/src/hooks/__tests__/useReplaceQueryParams.test.tsx
@@ -22,7 +22,7 @@ describe('useReplaceQueryParams hook', () => {
         mockNavigate.mockClear();
     });
 
-    it('should replace query params and reload if context not matching current params', () => {
+    it('should replace query params if context does not match current params', () => {
         useParams.mockReturnValueOnce(['testDb', 'testStat', 'testTable']);
         useNavigationContext.mockReturnValueOnce({
             tablePath: ['testDb2', 'testStat2', 'testTable2'],
@@ -37,7 +37,7 @@ describe('useReplaceQueryParams hook', () => {
         }, { replace: true});
     });
 
-    it('should replace query params and reload if current params are empty but context is not', () => {
+    it('should replace query params if current params are empty but context is not', () => {
         useParams.mockReturnValueOnce([null, null, null]);
         useNavigationContext.mockReturnValueOnce({
             tablePath: ['testDb', 'testStat', 'testTable'],

--- a/PxGraf.Frontend/src/hooks/useReplaceQueryParams.ts
+++ b/PxGraf.Frontend/src/hooks/useReplaceQueryParams.ts
@@ -1,10 +1,11 @@
 import { useNavigationContext } from "contexts/navigationContext";
 import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import useHierarchyParams from "./useHierarchyParams";
 
 const useReplaceQueryParams = (path: string): void => {
     const navigate = useNavigate();
+    const routerLocation = useLocation();
     const { tablePath } = useNavigationContext();
     const tablePathParams = useHierarchyParams();
 
@@ -13,9 +14,8 @@ const useReplaceQueryParams = (path: string): void => {
     useEffect(() => {
         if(shouldReplace) {
             navigate({pathname: path, search: `?tablePath=${tablePath.join(',')}`}, { replace: true });
-            navigate(0);
         }
-    }, [navigate, path, location, shouldReplace]);
+    }, [navigate, path, routerLocation, shouldReplace]);
 }
 
 export default useReplaceQueryParams;

--- a/PxGraf.Frontend/src/hooks/useReplaceQueryParams.ts
+++ b/PxGraf.Frontend/src/hooks/useReplaceQueryParams.ts
@@ -9,7 +9,7 @@ const useReplaceQueryParams = (path: string): void => {
     const { tablePath } = useNavigationContext();
     const tablePathParams = useHierarchyParams();
 
-    const shouldReplace: boolean = tablePath?.length && tablePath.join(',') !== tablePathParams?.join(',');
+    const shouldReplace = Boolean(tablePath?.length) && tablePath.join(',') !== tablePathParams?.join(',');
 
     useEffect(() => {
         if(shouldReplace) {

--- a/PxGraf.Frontend/src/hooks/useScrollToElement.ts
+++ b/PxGraf.Frontend/src/hooks/useScrollToElement.ts
@@ -4,11 +4,10 @@ const useScrollToElement = (id?: string, offset = 50) => {
     useEffect(() => {
         if(!id) return;
         const element = document.getElementById(id);
-        const elementX = element?.getBoundingClientRect().left + window.scrollX;
-        const elementY = element?.getBoundingClientRect().top + window.scrollY;
 
         if(element) {
-            window.scrollTo(elementX, elementY - offset);
+            const rect = element.getBoundingClientRect();
+            window.scrollTo(rect.left + window.scrollX, rect.top + window.scrollY - offset);
 
             const focusableElement: HTMLElement = element.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
             focusableElement?.focus();

--- a/PxGraf.Frontend/src/localization/en.json
+++ b/PxGraf.Frontend/src/localization/en.json
@@ -8,7 +8,7 @@
     "search": "Search",
     "selectDatabaseTitle": "Select database table",
     "editorTitle": "Selecting variables and making a visualisation",
-    "contentLink": "Gå till innehållet"
+    "contentLink": "Go to content"
   },
   "navbar": {
     "logoAlt": "Go to the home page"

--- a/PxGraf.Frontend/src/utils/sortingHelpers.ts
+++ b/PxGraf.Frontend/src/utils/sortingHelpers.ts
@@ -13,7 +13,7 @@ import { ISortableTableListItem } from 'types/tableListItems';
 export const sortDatabaseItems = <T extends ISortableTableListItem>(data: T[], primaryLanguage: string): T[] => {
     return [...data].sort((a, b) => {
         const textA = a.name[primaryLanguage] || a.name[a.languages[0]];
-        const textB = b.name[primaryLanguage] || b.name[a.languages[0]];
+        const textB = b.name[primaryLanguage] || b.name[b.languages[0]];
 
         return textA.localeCompare(textB, primaryLanguage);
     });

--- a/PxGraf.Frontend/src/utils/sortingHelpers.ts
+++ b/PxGraf.Frontend/src/utils/sortingHelpers.ts
@@ -39,7 +39,7 @@ export const sortedDimensions = (dimensions: IDimension[]): IDimension[] => {
         else if (dimension.type === EDimensionType.Time) {
             timeDimensions.push(dimension);
         }
-        else if (dimension.values.filter(vv => getValueIsSumValue(vv, dimension)).length > 0) {
+        else if (dimension.values.some(vv => getValueIsSumValue(vv, dimension))) {
             eliminationDimensions.push(dimension);
         }
         else if (dimension.values.length === 1) {
@@ -54,10 +54,7 @@ export const sortedDimensions = (dimensions: IDimension[]): IDimension[] => {
     if (contentDimension) {
         sortedDimensions.push(contentDimension);
     }
-    sortedDimensions.push(...timeDimensions);
-    sortedDimensions.push(...otherDimensions);
-    sortedDimensions.push(...eliminationDimensions);
-    sortedDimensions.push(...singleValueDimensions);
+    sortedDimensions.push(...timeDimensions, ...otherDimensions, ...eliminationDimensions, ...singleValueDimensions);
 
     return sortedDimensions;
 }

--- a/PxGraf.Frontend/src/views/QueryLoader/QueryLoader.tsx
+++ b/PxGraf.Frontend/src/views/QueryLoader/QueryLoader.tsx
@@ -59,4 +59,6 @@ export default function QueryLoader() {
             </Container>
         );
     }
+
+    return null;
 }

--- a/PxGraf.Frontend/src/views/TableListSelection/__snapshots__/TableListSelection.test.tsx.snap
+++ b/PxGraf.Frontend/src/views/TableListSelection/__snapshots__/TableListSelection.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Rendering test renders correctly 1`] = `
       <a
         class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-4bx69l-MuiButtonBase-root-MuiListItemButton-root"
         data-discover="true"
-        href="/table-list/f/o/o/b/a/r/id1/"
+        href="/table-list/foo/bar/id1/"
         id="mainContent"
         tabindex="0"
       >
@@ -31,7 +31,7 @@ exports[`Rendering test renders correctly 1`] = `
       <a
         class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-4bx69l-MuiButtonBase-root-MuiListItemButton-root"
         data-discover="true"
-        href="/table-list/f/o/o/b/a/r/id2/"
+        href="/table-list/foo/bar/id2/"
         id="mainContent"
         tabindex="0"
       >


### PR DESCRIPTION
API & networking:
- Replace manual query string building with URLSearchParams (trailing &, missing encoding)

Routing & navigation:
- Use react-router useLocation instead of global location in useReplaceQueryParams
- Remove navigate(0) full page reload after replace navigation
- Fix DirectoryInfo spreading string path into individual characters
- Add explicit return null for QueryLoader idle state

Null safety:
- Move null check before Object.keys iteration in ChartTypeRejectionReasons
- Add optional chaining for valueEdits access in BasicDimensionEditor
- Move getBoundingClientRect inside null guard in useScrollToElement

Localization & i18n:
- Add missing t() call for webhook error message in SuccessDialogContent
- Replace hardcoded Finnish label with t() in MultiselectableSelector
- Fix Swedish text in English locale (contentLink)

Logic errors:
- Use b.languages[0] instead of a.languages[0] for textB fallback in sortDatabaseItems
- Fix v.Code (PascalCase) to v.code in TablePivotSettings filter

HTML (index.html):
- Move root div before script tag
- Replace missing logo192.png with favicon.png
- Remove CRA-era HTML comments

Update affected tests and snapshots.