### PR TITLE
[Refactor] Split monolithic EditorContext into focused contexts

### DIFF
--- a/PxGraf.Frontend/package-lock.json
+++ b/PxGraf.Frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pxgraf",
-  "version": "2.5.11",
+  "version": "2.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pxgraf",
-      "version": "2.5.11",
+      "version": "2.5.12",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/PxGraf.Frontend/package.json
+++ b/PxGraf.Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxgraf",
-  "version": "2.5.11",
+  "version": "2.5.12",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/PxGraf.Frontend/src/components/ChartTypeSelector/ChartTypeSelector.test.tsx
+++ b/PxGraf.Frontend/src/components/ChartTypeSelector/ChartTypeSelector.test.tsx
@@ -2,32 +2,20 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { ChartTypeSelector } from './ChartTypeSelector';
 import '@testing-library/jest-dom';
-import { EditorContext } from '../../contexts/editorContext';
+import { VisualizationContext } from '../../contexts/visualizationContext';
 import { VisualizationType } from '../../types/visualizationType';
 
-const onTypeSelectedMock = jest.fn((value: string) => value);
+const onTypeSelectedMock = jest.fn();
 
 const mockTypes = ['foo', 'bar', 'baz'];
 
 const editorContextMock = {
     defaultSelectables: {},
     setDefaultSelectables: jest.fn(),
-    cubeQuery: null,
-    setCubeQuery: jest.fn(),
-    query: {},
-    setQuery: jest.fn(),
-    saveDialogOpen: false,
-    setSaveDialogOpen: jest.fn(),
     selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
     setSelectedVisualizationUserInput: onTypeSelectedMock,
     visualizationSettingsUserInput: {},
     setVisualizationSettingsUserInput: jest.fn(),
-    loadedQueryId: '',
-    setLoadedQueryId: jest.fn(),
-    loadedQueryIsDraft: false,
-    setLoadedQueryIsDraft: jest.fn(),
-    publicationWebhookEnabled: true,
-    setPublicationWebhookEnabled: jest.fn()
 };
 
 describe('Rendering test', () => {
@@ -44,18 +32,18 @@ describe('Assertion tests', () => {
 
     it('should invoke handler if clicked', () => {
         render(
-            <EditorContext.Provider value={editorContextMock}>
+            <VisualizationContext.Provider value={editorContextMock}>
                 <ChartTypeSelector possibleTypes={mockTypes} selectedType={'foo'} />
-            </EditorContext.Provider>);
+            </VisualizationContext.Provider>);
         fireEvent.click(screen.getByText('chartTypes.bar'));
         expect(onTypeSelectedMock).toHaveBeenCalledTimes(1);
     });
 
     it('renders all possible types as buttons', () => {
         render(
-            <EditorContext.Provider value={editorContextMock}>
+            <VisualizationContext.Provider value={editorContextMock}>
                 <ChartTypeSelector possibleTypes={mockTypes} selectedType={'foo'} />
-            </EditorContext.Provider>);
+            </VisualizationContext.Provider>);
         expect(screen.getByText('chartTypes.foo')).toBeInTheDocument();
         expect(screen.getByText('chartTypes.bar')).toBeInTheDocument();
         expect(screen.getByText('chartTypes.baz')).toBeInTheDocument();
@@ -63,25 +51,25 @@ describe('Assertion tests', () => {
 
     it('shows "no possible visualizations" when possibleTypes is empty', () => {
         render(
-            <EditorContext.Provider value={editorContextMock}>
+            <VisualizationContext.Provider value={editorContextMock}>
                 <ChartTypeSelector possibleTypes={[]} selectedType={'foo'} />
-            </EditorContext.Provider>);
+            </VisualizationContext.Provider>);
         expect(screen.getByText('general.noPossibleVisualizations')).toBeInTheDocument();
     });
 
     it('shows "no possible visualizations" when possibleTypes is null', () => {
         render(
-            <EditorContext.Provider value={editorContextMock}>
+            <VisualizationContext.Provider value={editorContextMock}>
                 <ChartTypeSelector possibleTypes={null} selectedType={'foo'} />
-            </EditorContext.Provider>);
+            </VisualizationContext.Provider>);
         expect(screen.getByText('general.noPossibleVisualizations')).toBeInTheDocument();
     });
 
     it('selects first type by default when selectedType is not provided', () => {
         render(
-            <EditorContext.Provider value={editorContextMock}>
+            <VisualizationContext.Provider value={editorContextMock}>
                 <ChartTypeSelector possibleTypes={mockTypes} />
-            </EditorContext.Provider>);
+            </VisualizationContext.Provider>);
         // First button should be selected (bold text)
         const firstButton = screen.getByText('chartTypes.foo');
         expect(firstButton.tagName).toBe('B');
@@ -89,18 +77,18 @@ describe('Assertion tests', () => {
 
     it('invokes handler with correct value when different types are clicked', () => {
         render(
-            <EditorContext.Provider value={editorContextMock}>
+            <VisualizationContext.Provider value={editorContextMock}>
                 <ChartTypeSelector possibleTypes={mockTypes} selectedType={'foo'} />
-            </EditorContext.Provider>);
+            </VisualizationContext.Provider>);
         fireEvent.click(screen.getByText('chartTypes.baz'));
         expect(onTypeSelectedMock).toHaveBeenCalledWith('baz');
     });
 
     it('renders toggle button group with correct aria-label', () => {
         render(
-            <EditorContext.Provider value={editorContextMock}>
+            <VisualizationContext.Provider value={editorContextMock}>
                 <ChartTypeSelector possibleTypes={mockTypes} selectedType={'foo'} />
-            </EditorContext.Provider>);
+            </VisualizationContext.Provider>);
         expect(screen.getByRole('group')).toHaveAttribute('aria-label', 'tooltip.visualizationType');
     });
 });

--- a/PxGraf.Frontend/src/components/ChartTypeSelector/ChartTypeSelector.tsx
+++ b/PxGraf.Frontend/src/components/ChartTypeSelector/ChartTypeSelector.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { ToggleButton, ToggleButtonGroup } from '@mui/material';
 import React from 'react';
-import { EditorContext } from '../../contexts/editorContext';
+import { VisualizationContext } from '../../contexts/visualizationContext';
 
 interface IChartTypeSelectorProps {
     possibleTypes: string[];
@@ -11,9 +11,9 @@ interface IChartTypeSelectorProps {
 export const ChartTypeSelector: React.FC<IChartTypeSelectorProps> = ({ possibleTypes, selectedType }) => {
     const { t } = useTranslation();
     const isSelected = (type) => {
-        return !selectedType ? type === possibleTypes[0] : selectedType === type;
+        return selectedType ? selectedType === type : type === possibleTypes[0];
     };
-    const { setSelectedVisualizationUserInput } = React.useContext(EditorContext);
+    const { setSelectedVisualizationUserInput } = React.useContext(VisualizationContext);
 
     return (
         <ToggleButtonGroup

--- a/PxGraf.Frontend/src/components/MetaEditor/BasicDimensionEditor.test.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/BasicDimensionEditor.test.tsx
@@ -5,8 +5,7 @@ import { ICubeQuery } from 'types/query';
 import BasicDimensionEditor from './BasicDimensionEditor';
 import '@testing-library/jest-dom';
 import UiLanguageContext from 'contexts/uiLanguageContext';
-import { EditorContext } from '../../contexts/editorContext';
-import { VisualizationType } from '../../types/visualizationType';
+import { QueryContext } from '../../contexts/queryContext';
 
 const setLanguage = jest.fn();
 const language = 'fi';
@@ -61,28 +60,14 @@ describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
-                    defaultSelectables: {},
-                    setDefaultSelectables: jest.fn(),
+                <QueryContext.Provider value={{
                     cubeQuery: mockDimEdits,
                     setCubeQuery: mockFunction,
                     query: {},
                     setQuery: jest.fn(),
-                    saveDialogOpen: false,
-                    setSaveDialogOpen: jest.fn(),
-                    selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                    setSelectedVisualizationUserInput: jest.fn(),
-                    visualizationSettingsUserInput: {},
-                    setVisualizationSettingsUserInput: jest.fn(),
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <BasicDimensionEditor language={mockLang} dimension={mockDimension} />
-                </EditorContext.Provider>
+                </QueryContext.Provider>
             </UiLanguageContext.Provider>
         );
         expect(asFragment()).toMatchSnapshot();
@@ -93,28 +78,14 @@ describe('Assertion tests', () => {
     it('Change event should fire when value has changed', () => {
         render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
-                    defaultSelectables: {},
-                    setDefaultSelectables: jest.fn(),
+                <QueryContext.Provider value={{
                     cubeQuery: mockDimEdits,
                     setCubeQuery: mockFunction,
                     query: {},
                     setQuery: jest.fn(),
-                    saveDialogOpen: false,
-                    setSaveDialogOpen: jest.fn(),
-                    selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                    setSelectedVisualizationUserInput: jest.fn(),
-                    visualizationSettingsUserInput: {},
-                    setVisualizationSettingsUserInput: jest.fn(),
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <BasicDimensionEditor language={mockLang} dimension={mockDimension} />
-                </EditorContext.Provider>
+                </QueryContext.Provider>
             </UiLanguageContext.Provider>
         );
         fireEvent.change(screen.getByDisplayValue('bar'), { target: { value: 'editValue2' } });

--- a/PxGraf.Frontend/src/components/MetaEditor/BasicDimensionEditor.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/BasicDimensionEditor.tsx
@@ -5,7 +5,7 @@ import { UiLanguageContext } from 'contexts/uiLanguageContext';
 import { EditorField } from './Editorfield';
 import styled from 'styled-components';
 import { IDimension } from 'types/cubeMeta';
-import { EditorContext } from '../../contexts/editorContext';
+import { QueryContext } from '../../contexts/queryContext';
 
 const EditorFieldWrapper = styled(Stack)`
   padding: 0px;
@@ -19,7 +19,7 @@ interface IBasicDimensionEditor {
 export const BasicDimensionEditor: React.FC<IBasicDimensionEditor> = ({ dimension, language }) => {
     const { t } = useTranslation();
     const { uiContentLanguage } = React.useContext(UiLanguageContext);
-    const { cubeQuery, setCubeQuery } = React.useContext(EditorContext);
+    const { cubeQuery, setCubeQuery } = React.useContext(QueryContext);
     const dimensionEdits = cubeQuery?.variableQueries[dimension.code];
 
     const handleChange = (newValue: string, valueCode: string) => {

--- a/PxGraf.Frontend/src/components/MetaEditor/ContentDimensionEditor.test.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/ContentDimensionEditor.test.tsx
@@ -5,8 +5,7 @@ import { EMetaPropertyType, IDimension, EDimensionType } from 'types/cubeMeta';
 import { ICubeQuery, IDimensionEditions } from 'types/query';
 import { ContentDimensionEditor } from './ContentDimensionEditor';
 import UiLanguageContext from 'contexts/uiLanguageContext';
-import { EditorContext } from '../../contexts/editorContext';
-import { VisualizationType } from '../../types/visualizationType';
+import { QueryContext } from '../../contexts/queryContext';
 
 const setLanguage = jest.fn();
 const language = 'fi';
@@ -77,28 +76,14 @@ describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
-                    defaultSelectables: {},
-                    setDefaultSelectables: jest.fn(),
+                <QueryContext.Provider value={{
                     cubeQuery: mockCubeQuery,
                     setCubeQuery: mockFunction,
                     query: {},
                     setQuery: jest.fn(),
-                    saveDialogOpen: false,
-                    setSaveDialogOpen: jest.fn(),
-                    selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                    setSelectedVisualizationUserInput: jest.fn(),
-                    visualizationSettingsUserInput: {},
-                    setVisualizationSettingsUserInput: jest.fn(),
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <ContentDimensionEditor language={mockLang} dimension={mockDimension} />
-                </EditorContext.Provider>
+                </QueryContext.Provider>
             </UiLanguageContext.Provider>
         );
         expect(asFragment()).toMatchSnapshot();

--- a/PxGraf.Frontend/src/components/MetaEditor/ContentDimensionEditor.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/ContentDimensionEditor.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IContentDimensionValue, IDimension } from 'types/cubeMeta';
 import { IDimensionValueEditions } from 'types/query';
 import { ContentDimensionValueEditor } from './ContentDimensionValueEditor';
-import { EditorContext } from '../../contexts/editorContext';
+import { QueryContext } from '../../contexts/queryContext';
 
 interface IContentDimensionEditorProps {
     dimension: IDimension;
@@ -11,7 +11,7 @@ interface IContentDimensionEditorProps {
 }
 
 export const ContentDimensionEditor: React.FC<IContentDimensionEditorProps> = ({ dimension, language }) => {
-    const { cubeQuery, setCubeQuery } = React.useContext(EditorContext);
+    const { cubeQuery, setCubeQuery } = React.useContext(QueryContext);
     const dimensionEdits = cubeQuery?.variableQueries[dimension.code];
 
     const handleChange = (newValueEdits: IDimensionValueEditions, code: string) => {

--- a/PxGraf.Frontend/src/components/MetaEditor/DimensionEditor.test.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/DimensionEditor.test.tsx
@@ -5,8 +5,7 @@ import { EMetaPropertyType, IDimension, EDimensionType } from 'types/cubeMeta';
 import { ICubeQuery, IDimensionEditions } from 'types/query';
 import DimensionEditor from './DimensionEditor';
 import UiLanguageContext from 'contexts/uiLanguageContext';
-import { EditorContext } from '../../contexts/editorContext';
-import { VisualizationType } from '../../types/visualizationType';
+import { QueryContext } from '../../contexts/queryContext';
 
 const mockDimension: IDimension = {
     code: 'foo',
@@ -75,28 +74,14 @@ describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
+                <QueryContext.Provider value={{
                     cubeQuery: mockCubeQuery,
                     setCubeQuery: jest.fn(),
                     query: {},
                     setQuery: jest.fn(),
-                    saveDialogOpen: false,
-                    setSaveDialogOpen: jest.fn(),
-                    selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                    setSelectedVisualizationUserInput: jest.fn(),
-                    visualizationSettingsUserInput: {},
-                    setVisualizationSettingsUserInput: jest.fn(),
-                    defaultSelectables: {},
-                    setDefaultSelectables: jest.fn(),
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <DimensionEditor language={mockLang} dimension={mockDimension} />
-                </EditorContext.Provider>
+                </QueryContext.Provider>
             </UiLanguageContext.Provider>
         );
         expect(asFragment()).toMatchSnapshot();

--- a/PxGraf.Frontend/src/components/MetaEditor/HeaderEditor.test.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/HeaderEditor.test.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import HeaderEditor from './HeaderEditor';
-import { EditorContext } from '../../contexts/editorContext';
-import { VisualizationType } from '../../types/visualizationType';
+import { QueryContext } from '../../contexts/queryContext';
 import { ICubeQuery } from '../../types/query';
 import { IEditorContentsResult } from '../../api/services/editor-contents';
 import { IEditorContentsResponse } from '../../types/editorContentsResponse';
@@ -43,28 +42,14 @@ const mockCubeQuery: ICubeQuery = {
 describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(
-            <EditorContext.Provider value={{
-                defaultSelectables: {},
-                setDefaultSelectables: jest.fn(),
+            <QueryContext.Provider value={{
                 cubeQuery: mockCubeQuery,
                 setCubeQuery: mockFunction,
                 query: {},
                 setQuery: jest.fn(),
-                saveDialogOpen: false,
-                setSaveDialogOpen: jest.fn(),
-                selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                setSelectedVisualizationUserInput: jest.fn(),
-                visualizationSettingsUserInput: {},
-                setVisualizationSettingsUserInput: jest.fn(),
-                loadedQueryId: '',
-                setLoadedQueryId: jest.fn(),
-                loadedQueryIsDraft: false,
-                setLoadedQueryIsDraft: jest.fn(),
-                publicationWebhookEnabled: true,
-                setPublicationWebhookEnabled: jest.fn()
             }}>
                 <HeaderEditor editorContentResponse={mockDefaultResponse} language={mockLang} style={{}} />
-            </EditorContext.Provider>
+            </QueryContext.Provider>
         );
         expect(asFragment()).toMatchSnapshot();
     });
@@ -73,28 +58,14 @@ describe('Rendering test', () => {
 describe('Assertion tests', () => {
     it('Change event should fire when value has changed', () => {
         render(
-            <EditorContext.Provider value={{
-                defaultSelectables: {},
-                setDefaultSelectables: jest.fn(),
+            <QueryContext.Provider value={{
                 cubeQuery: mockCubeQuery,
                 setCubeQuery: mockFunction,
                 query: {},
                 setQuery: jest.fn(),
-                saveDialogOpen: false,
-                setSaveDialogOpen: jest.fn(),
-                selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                setSelectedVisualizationUserInput: jest.fn(),
-                visualizationSettingsUserInput: {},
-                setVisualizationSettingsUserInput: jest.fn(),
-                loadedQueryId: '',
-                setLoadedQueryId: jest.fn(),
-                loadedQueryIsDraft: false,
-                setLoadedQueryIsDraft: jest.fn(),
-                publicationWebhookEnabled: true,
-                setPublicationWebhookEnabled: jest.fn()
             }}>
                 <HeaderEditor editorContentResponse={mockDefaultResponse} language={mockLang} style={{}} />
-            </EditorContext.Provider>
+            </QueryContext.Provider>
         );
         fireEvent.change(screen.getByDisplayValue(mockCubeQuery.chartHeaderEdit['fi']), { target: { value: 'editValue2' } });
         expect(mockFunction).toHaveBeenCalledTimes(1);

--- a/PxGraf.Frontend/src/components/MetaEditor/HeaderEditor.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/HeaderEditor.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { EditorField } from './Editorfield';
 import InfoBubble from 'components/InfoBubble/InfoBubble';
 import styled from 'styled-components';
-import { EditorContext } from '../../contexts/editorContext';
+import { QueryContext } from '../../contexts/queryContext';
 import { MultiLanguageString } from '../../types/multiLanguageString';
 import { IEditorContentsResult } from '../../api/services/editor-contents';
 
@@ -25,7 +25,7 @@ const GridFixer = styled.div`
 export const HeaderEditor: React.FC<IHeaderEditorProps> = ({ editorContentResponse, language, maxLength, style = {} }) => {
     const { t } = useTranslation();
 
-    const { cubeQuery, setCubeQuery } = React.useContext(EditorContext);
+    const { cubeQuery, setCubeQuery } = React.useContext(QueryContext);
     const editValue = cubeQuery?.chartHeaderEdit;
     const editHeader = (title: MultiLanguageString) => setCubeQuery({ ...cubeQuery, chartHeaderEdit: title })
 

--- a/PxGraf.Frontend/src/components/MetaEditor/MetaEditor.test.tsx
+++ b/PxGraf.Frontend/src/components/MetaEditor/MetaEditor.test.tsx
@@ -5,7 +5,7 @@ import { EMetaPropertyType, IDimension, EDimensionType } from 'types/cubeMeta';
 import { ICubeQuery } from 'types/query';
 import MetaEditor from './MetaEditor';
 import UiLanguageContext from 'contexts/uiLanguageContext';
-import { EditorContext } from 'contexts/editorContext';
+import { QueryContext } from 'contexts/queryContext';
 import { IEditorContentsResult } from '../../api/services/editor-contents';
 import { IEditorContentsResponse } from '../../types/editorContentsResponse';
 
@@ -155,7 +155,7 @@ describe('Rendering test', () => {
     it('renders correctly', () => {
         const { asFragment } = render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{ cubeQuery: mockCubeQuery, setCubeQuery, query, setQuery, saveDialogOpen, setSaveDialogOpen, selectedVisualizationUserInput, setSelectedVisualizationUserInput, visualizationSettingsUserInput, setVisualizationSettingsUserInput, defaultSelectables, setDefaultSelectables, loadedQueryId: '', setLoadedQueryId: jest.fn(), loadedQueryIsDraft: false, setLoadedQueryIsDraft: jest.fn(), publicationWebhookEnabled: true, setPublicationWebhookEnabled: jest.fn() }}>
+                <QueryContext.Provider value={{ cubeQuery: mockCubeQuery, setCubeQuery, query, setQuery }}>
                     <MetaEditor
                         resolvedDimensions={mockDimensions}
                         editorContentsResponse={defaultHeaderResponseMock}
@@ -163,7 +163,7 @@ describe('Rendering test', () => {
                         language={mockLang}
                         onMetaAccordionOpenChange={mockFunction}
                     />
-                </EditorContext.Provider>
+                </QueryContext.Provider>
             </UiLanguageContext.Provider>
         );
         expect(asFragment()).toMatchSnapshot();

--- a/PxGraf.Frontend/src/components/Preview/Preview.test.tsx
+++ b/PxGraf.Frontend/src/components/Preview/Preview.test.tsx
@@ -7,7 +7,8 @@ import { EVariableType, EVisualizationType, ETimeVariableInterval, IQueryVisuali
 import { IVisualizationResult } from "api/services/visualization";
 import serializer from "../../testUtils/stripHighchartsHashes";
 import UiLanguageContext from "../../contexts/uiLanguageContext";
-import { EditorContext } from "../../contexts/editorContext";
+import { QueryContext } from "../../contexts/queryContext";
+import { VisualizationContext } from "../../contexts/visualizationContext";
 import { ISelectableSelections } from "../SelectableVariableMenus/SelectableDimensionMenus";
 import { EDimensionType } from "../../types/cubeMeta";
 
@@ -231,33 +232,28 @@ describe('Rendering test', () => {
                 setUiContentLanguage: jest.fn(),
                 availableUiLanguages: ['fi', 'en', 'sv'],
             }}>
-                <EditorContext.Provider value={{
+                <QueryContext.Provider value={{
                     cubeQuery: mockCubeQueryTextEdits,
                     setCubeQuery,
                     query,
                     setQuery,
-                    saveDialogOpen,
-                    setSaveDialogOpen,
-                    selectedVisualizationUserInput,
-                    setSelectedVisualizationUserInput,
-                    visualizationSettingsUserInput,
-                    setVisualizationSettingsUserInput,
-                    defaultSelectables,
-                    setDefaultSelectables,
-                    loadedQueryId,
-                    setLoadedQueryId,
-                    loadedQueryIsDraft,
-                    setLoadedQueryIsDraft,
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
-                    <Preview
-                        path={mockPath}
-                        query={mockQuery}
-                        selectedVisualization={mockSelectedVisualization}
-                        visualizationSettings={mockVisualizationSettings}
-                    />
-                </EditorContext.Provider>
+                    <VisualizationContext.Provider value={{
+                        selectedVisualizationUserInput,
+                        setSelectedVisualizationUserInput,
+                        visualizationSettingsUserInput,
+                        setVisualizationSettingsUserInput,
+                        defaultSelectables,
+                        setDefaultSelectables,
+                    }}>
+                        <Preview
+                            path={mockPath}
+                            query={mockQuery}
+                            selectedVisualization={mockSelectedVisualization}
+                            visualizationSettings={mockVisualizationSettings}
+                        />
+                    </VisualizationContext.Provider>
+                </QueryContext.Provider>
             </UiLanguageContext.Provider>);
 
         expect(asFragment()).toMatchSnapshot();

--- a/PxGraf.Frontend/src/components/Preview/Preview.tsx
+++ b/PxGraf.Frontend/src/components/Preview/Preview.tsx
@@ -10,7 +10,8 @@ import { Chart, IQueryVisualizationResponse } from '@statisticsfinland/pxvisuali
 import useSelections from 'components/SelectableVariableMenus/hooks/useSelections';
 import InfoBubble from 'components/InfoBubble/InfoBubble';
 import { IVariable } from '../../types/visualizationResponse';
-import { EditorContext } from '../../contexts/editorContext';
+import { QueryContext } from '../../contexts/queryContext';
+import { VisualizationContext } from '../../contexts/visualizationContext';
 import UiLanguageContext from '../../contexts/uiLanguageContext';
 import { EDimensionType } from '../../types/cubeMeta';
 
@@ -100,7 +101,8 @@ export const getResolvedSelections = (selectables: ISelectabilityInfo[], selecti
 export const Preview: React.FC<IPreviewProps> = ({ path, query, selectedVisualization, visualizationSettings }) => {
     const { t } = useTranslation();
     const { languageTab } = React.useContext(UiLanguageContext);
-    const { cubeQuery, defaultSelectables } = React.useContext(EditorContext);
+    const { cubeQuery } = React.useContext(QueryContext);
+    const { defaultSelectables } = React.useContext(VisualizationContext);
     const { data, isLoading, isError } = useVisualizationQuery(path, query, cubeQuery, languageTab, selectedVisualization, visualizationSettings);
     const showVisualization = data && !isLoading && !isError;
     const { selections, setSelections } = useSelections();

--- a/PxGraf.Frontend/src/components/SaveDialog/SaveDialog.test.tsx
+++ b/PxGraf.Frontend/src/components/SaveDialog/SaveDialog.test.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { SaveDialog } from './SaveDialog';
-import { EditorContext } from '../../contexts/editorContext';
-import { VisualizationType } from '../../types/visualizationType';
+import { SaveContext } from '../../contexts/saveContext';
 
 const onCloseMock = jest.fn();
 const onSaveMock = jest.fn(() => { });
@@ -17,19 +16,9 @@ describe('Rendering test', () => {
 
     it('renders correctly when open', () => {
         const dom = render(
-            <EditorContext.Provider value={{
-                cubeQuery: null,
-                setCubeQuery: jest.fn(),
-                query: {},
-                setQuery: jest.fn(),
+            <SaveContext.Provider value={{
                 saveDialogOpen: true,
                 setSaveDialogOpen: onCloseMock,
-                selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                setSelectedVisualizationUserInput: jest.fn(),
-                visualizationSettingsUserInput: {},
-                setVisualizationSettingsUserInput: jest.fn(),
-                defaultSelectables: {},
-                setDefaultSelectables: jest.fn(),
                 loadedQueryId: '',
                 setLoadedQueryId: jest.fn(),
                 loadedQueryIsDraft: false,
@@ -38,26 +27,16 @@ describe('Rendering test', () => {
                 setPublicationWebhookEnabled: jest.fn()
             }}>
                 <SaveDialog onSave={onSaveMock} />
-            </EditorContext.Provider>
+            </SaveContext.Provider>
         );
         expect(dom.baseElement).toMatchSnapshot();
     });
 
     it('renders correctly when open and publication webhook is disabled', () => {
         const dom = render(
-            <EditorContext.Provider value={{
-                cubeQuery: null,
-                setCubeQuery: jest.fn(),
-                query: {},
-                setQuery: jest.fn(),
+            <SaveContext.Provider value={{
                 saveDialogOpen: true,
                 setSaveDialogOpen: onCloseMock,
-                selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                setSelectedVisualizationUserInput: jest.fn(),
-                visualizationSettingsUserInput: {},
-                setVisualizationSettingsUserInput: jest.fn(),
-                defaultSelectables: {},
-                setDefaultSelectables: jest.fn(),
                 loadedQueryId: '',
                 setLoadedQueryId: jest.fn(),
                 loadedQueryIsDraft: false,
@@ -66,7 +45,7 @@ describe('Rendering test', () => {
                 setPublicationWebhookEnabled: jest.fn()
             }}>
                 <SaveDialog onSave={onSaveMock} />
-            </EditorContext.Provider>
+            </SaveContext.Provider>
         );
         expect(dom.baseElement).toMatchSnapshot();
     });
@@ -81,19 +60,9 @@ describe('Assertion test', () => {
 
     it('invokes close function when cancel button is clicked', () => {
         render(
-            <EditorContext.Provider value={{
-                cubeQuery: null,
-                setCubeQuery: jest.fn(),
-                query: {},
-                setQuery: jest.fn(),
+            <SaveContext.Provider value={{
                 saveDialogOpen: true,
                 setSaveDialogOpen: onCloseMock,
-                selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                setSelectedVisualizationUserInput: jest.fn(),
-                visualizationSettingsUserInput: {},
-                setVisualizationSettingsUserInput: jest.fn(),
-                defaultSelectables: {},
-                setDefaultSelectables: jest.fn(),
                 loadedQueryId: '',
                 setLoadedQueryId: jest.fn(),
                 loadedQueryIsDraft: false,
@@ -102,7 +71,7 @@ describe('Assertion test', () => {
                 setPublicationWebhookEnabled: jest.fn()
             }}>
                 <SaveDialog onSave={onSaveMock} />
-            </EditorContext.Provider>
+            </SaveContext.Provider>
         );
         fireEvent.click(screen.getByText('saveDialog.cancel'));
         expect(onCloseMock).toHaveBeenCalledTimes(1);
@@ -110,19 +79,9 @@ describe('Assertion test', () => {
 
     it('invokes save and close function when save button is clicked', () => {
         render(
-            <EditorContext.Provider value={{
-                cubeQuery: null,
-                setCubeQuery: jest.fn(),
-                query: {},
-                setQuery: jest.fn(),
+            <SaveContext.Provider value={{
                 saveDialogOpen: true,
                 setSaveDialogOpen: onCloseMock,
-                selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                setSelectedVisualizationUserInput: jest.fn(),
-                visualizationSettingsUserInput: {},
-                setVisualizationSettingsUserInput: jest.fn(),
-                defaultSelectables: {},
-                setDefaultSelectables: jest.fn(),
                 loadedQueryId: '',
                 setLoadedQueryId: jest.fn(),
                 loadedQueryIsDraft: false,
@@ -131,7 +90,7 @@ describe('Assertion test', () => {
                 setPublicationWebhookEnabled: jest.fn()
             }}>
                 <SaveDialog onSave={onSaveMock} />
-            </EditorContext.Provider>
+            </SaveContext.Provider>
         );
         fireEvent.click(screen.getByText('saveDialog.save'));
         expect(onSaveMock).toHaveBeenCalledTimes(1);
@@ -140,19 +99,9 @@ describe('Assertion test', () => {
 
     it('invokes save and close function with draft as true when publish checkbox is unchecked', () => {
         render(
-            <EditorContext.Provider value={{
-                cubeQuery: null,
-                setCubeQuery: jest.fn(),
-                query: {},
-                setQuery: jest.fn(),
+            <SaveContext.Provider value={{
                 saveDialogOpen: true,
                 setSaveDialogOpen: onCloseMock,
-                selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                setSelectedVisualizationUserInput: jest.fn(),
-                visualizationSettingsUserInput: {},
-                setVisualizationSettingsUserInput: jest.fn(),
-                defaultSelectables: {},
-                setDefaultSelectables: jest.fn(),
                 loadedQueryId: '',
                 setLoadedQueryId: jest.fn(),
                 loadedQueryIsDraft: false,
@@ -161,7 +110,7 @@ describe('Assertion test', () => {
                 setPublicationWebhookEnabled: jest.fn()
             }}>
                 <SaveDialog onSave={onSaveMock} />
-            </EditorContext.Provider>
+            </SaveContext.Provider>
         );
 
         // Checkbox is unchecked by default (saveAsPublished = false)
@@ -173,19 +122,9 @@ describe('Assertion test', () => {
 
     it('invokes save and close function with draft as false when publish checkbox is checked', () => {
         render(
-            <EditorContext.Provider value={{
-                cubeQuery: null,
-                setCubeQuery: jest.fn(),
-                query: {},
-                setQuery: jest.fn(),
+            <SaveContext.Provider value={{
                 saveDialogOpen: true,
                 setSaveDialogOpen: onCloseMock,
-                selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                setSelectedVisualizationUserInput: jest.fn(),
-                visualizationSettingsUserInput: {},
-                setVisualizationSettingsUserInput: jest.fn(),
-                defaultSelectables: {},
-                setDefaultSelectables: jest.fn(),
                 loadedQueryId: '',
                 setLoadedQueryId: jest.fn(),
                 loadedQueryIsDraft: false,
@@ -194,7 +133,7 @@ describe('Assertion test', () => {
                 setPublicationWebhookEnabled: jest.fn()
             }}>
                 <SaveDialog onSave={onSaveMock} />
-            </EditorContext.Provider>
+            </SaveContext.Provider>
         );
 
         // Check the publish checkbox
@@ -207,19 +146,9 @@ describe('Assertion test', () => {
 
     it('saves as static when static radio option is selected', () => {
         render(
-            <EditorContext.Provider value={{
-                cubeQuery: null,
-                setCubeQuery: jest.fn(),
-                query: {},
-                setQuery: jest.fn(),
+            <SaveContext.Provider value={{
                 saveDialogOpen: true,
                 setSaveDialogOpen: onCloseMock,
-                selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                setSelectedVisualizationUserInput: jest.fn(),
-                visualizationSettingsUserInput: {},
-                setVisualizationSettingsUserInput: jest.fn(),
-                defaultSelectables: {},
-                setDefaultSelectables: jest.fn(),
                 loadedQueryId: '',
                 setLoadedQueryId: jest.fn(),
                 loadedQueryIsDraft: false,
@@ -228,7 +157,7 @@ describe('Assertion test', () => {
                 setPublicationWebhookEnabled: jest.fn()
             }}>
                 <SaveDialog onSave={onSaveMock} />
-            </EditorContext.Provider>
+            </SaveContext.Provider>
         );
         fireEvent.click(screen.getByLabelText('saveDialog.saveStatic'));
         fireEvent.click(screen.getByText('saveDialog.save'));
@@ -237,19 +166,9 @@ describe('Assertion test', () => {
 
     it('does not render publish checkbox when publication webhook is disabled', () => {
         render(
-            <EditorContext.Provider value={{
-                cubeQuery: null,
-                setCubeQuery: jest.fn(),
-                query: {},
-                setQuery: jest.fn(),
+            <SaveContext.Provider value={{
                 saveDialogOpen: true,
                 setSaveDialogOpen: onCloseMock,
-                selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                setSelectedVisualizationUserInput: jest.fn(),
-                visualizationSettingsUserInput: {},
-                setVisualizationSettingsUserInput: jest.fn(),
-                defaultSelectables: {},
-                setDefaultSelectables: jest.fn(),
                 loadedQueryId: '',
                 setLoadedQueryId: jest.fn(),
                 loadedQueryIsDraft: false,
@@ -258,26 +177,16 @@ describe('Assertion test', () => {
                 setPublicationWebhookEnabled: jest.fn()
             }}>
                 <SaveDialog onSave={onSaveMock} />
-            </EditorContext.Provider>
+            </SaveContext.Provider>
         );
         expect(screen.queryByText('saveDialog.publish')).not.toBeInTheDocument();
     });
 
     it('saves as non-draft when publication webhook is disabled regardless of checkbox', () => {
         render(
-            <EditorContext.Provider value={{
-                cubeQuery: null,
-                setCubeQuery: jest.fn(),
-                query: {},
-                setQuery: jest.fn(),
+            <SaveContext.Provider value={{
                 saveDialogOpen: true,
                 setSaveDialogOpen: onCloseMock,
-                selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                setSelectedVisualizationUserInput: jest.fn(),
-                visualizationSettingsUserInput: {},
-                setVisualizationSettingsUserInput: jest.fn(),
-                defaultSelectables: {},
-                setDefaultSelectables: jest.fn(),
                 loadedQueryId: '',
                 setLoadedQueryId: jest.fn(),
                 loadedQueryIsDraft: false,
@@ -286,7 +195,7 @@ describe('Assertion test', () => {
                 setPublicationWebhookEnabled: jest.fn()
             }}>
                 <SaveDialog onSave={onSaveMock} />
-            </EditorContext.Provider>
+            </SaveContext.Provider>
         );
         fireEvent.click(screen.getByText('saveDialog.save'));
         expect(onSaveMock).toHaveBeenCalledWith(false, false); // draft is always false when webhook disabled
@@ -294,19 +203,9 @@ describe('Assertion test', () => {
 
     it('renders dialog title and radio options when open', () => {
         render(
-            <EditorContext.Provider value={{
-                cubeQuery: null,
-                setCubeQuery: jest.fn(),
-                query: {},
-                setQuery: jest.fn(),
+            <SaveContext.Provider value={{
                 saveDialogOpen: true,
                 setSaveDialogOpen: onCloseMock,
-                selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-                setSelectedVisualizationUserInput: jest.fn(),
-                visualizationSettingsUserInput: {},
-                setVisualizationSettingsUserInput: jest.fn(),
-                defaultSelectables: {},
-                setDefaultSelectables: jest.fn(),
                 loadedQueryId: '',
                 setLoadedQueryId: jest.fn(),
                 loadedQueryIsDraft: false,
@@ -315,7 +214,7 @@ describe('Assertion test', () => {
                 setPublicationWebhookEnabled: jest.fn()
             }}>
                 <SaveDialog onSave={onSaveMock} />
-            </EditorContext.Provider>
+            </SaveContext.Provider>
         );
         expect(screen.getByText('saveDialog.saveQuery')).toBeInTheDocument();
         expect(screen.getByLabelText('saveDialog.saveDynamic')).toBeInTheDocument();

--- a/PxGraf.Frontend/src/components/SaveDialog/SaveDialog.tsx
+++ b/PxGraf.Frontend/src/components/SaveDialog/SaveDialog.tsx
@@ -5,7 +5,7 @@ import {
     DialogContent, DialogActions, FormLabel, RadioGroup, Radio, Checkbox
 } from '@mui/material';
 import SaveIcon from '@mui/icons-material/Save';
-import { EditorContext } from '../../contexts/editorContext';
+import { SaveContext } from '../../contexts/saveContext';
 
 interface ISaveDialogProps {
     onSave: (archive: boolean, draft: boolean) => void;
@@ -20,7 +20,7 @@ interface ISaveDialogProps {
 export const SaveDialog: React.FC<ISaveDialogProps> = ({ onSave }) => {
     const { t } = useTranslation();
     const [selected, setSelected] = useState("dynamic");
-    const { saveDialogOpen, setSaveDialogOpen, publicationWebhookEnabled } = React.useContext(EditorContext);
+    const { saveDialogOpen, setSaveDialogOpen, publicationWebhookEnabled } = React.useContext(SaveContext);
     const [saveAsPublished, setSaveAsPublished] = useState(false);
 
     const handleDraftChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/PxGraf.Frontend/src/components/SaveResultDialog/SaveResultDialog.test.tsx
+++ b/PxGraf.Frontend/src/components/SaveResultDialog/SaveResultDialog.test.tsx
@@ -4,8 +4,7 @@ import '@testing-library/jest-dom';
 import SaveResultDialog from './SaveResultDialog';
 import { EQueryPublicationStatus } from "types/saveQuery";
 import { ISaveQueryResult } from 'api/services/queries';
-import { EditorContext } from '../../contexts/editorContext';
-import { VisualizationType } from '../../types/visualizationType';
+
 
 const mockSuccessMutation: ISaveQueryResult = {
     isPending: false,
@@ -39,68 +38,33 @@ const mockErrorMutation: ISaveQueryResult = {
 
 const onCloseMock = jest.fn();
 
-const mockEditorContextPublicationTrue = {
-    cubeQuery: null,
-    setCubeQuery: jest.fn(),
-    query: {},
-    setQuery: jest.fn(),
-    saveDialogOpen: false,
-    setSaveDialogOpen: jest.fn(),
-    selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
-    setSelectedVisualizationUserInput: jest.fn(),
-    visualizationSettingsUserInput: {},
-    setVisualizationSettingsUserInput: jest.fn(),
-    defaultSelectables: {},
-    setDefaultSelectables: jest.fn(),
-    loadedQueryId: '',
-    setLoadedQueryId: jest.fn(),
-    loadedQueryIsDraft: false,
-    setLoadedQueryIsDraft: jest.fn(),
-    publicationWebhookEnabled: true,
-    setPublicationWebhookEnabled: jest.fn()
-};
-
 
 
 describe('Rendering test', () => {
     it('renders correctly when closed', () => {
         const dom = render(
-            <EditorContext.Provider value={mockEditorContextPublicationTrue}>
                 <SaveResultDialog mutation={mockSuccessMutation} onClose={onCloseMock} open={false} />
-            </EditorContext.Provider>
         );
         expect(dom.baseElement).toMatchSnapshot();
     });
 
     it('renders correctly when open', () => {
         const dom = render(
-            <EditorContext.Provider value={mockEditorContextPublicationTrue}>
                 <SaveResultDialog mutation={mockSuccessMutation} onClose={onCloseMock} open={true} />
-            </EditorContext.Provider>
         );
         expect(dom.baseElement).toMatchSnapshot();
     });
 
     it('renders correctly when open with publication disabled', () => {
-        const mockEditorContextPublicationFalse = {
-            ...mockEditorContextPublicationTrue,
-            publicationWebhookEnabled: false,
-            setPublicationWebhookEnabled: jest.fn()
-        };
-
         const dom = render(
-            <EditorContext.Provider value={mockEditorContextPublicationFalse}>
                 <SaveResultDialog mutation={mockSuccessMutation} onClose={onCloseMock} open={true} />
-            </EditorContext.Provider>
         );
         expect(dom.baseElement).toMatchSnapshot();
     });
 
     it('renders correctly when open (draft)', () => {
         const dom = render(
-            <EditorContext.Provider value={mockEditorContextPublicationTrue}>
                 <SaveResultDialog mutation={mockSuccessDraftMutation} onClose={onCloseMock} open={true} />
-            </EditorContext.Provider>
         );
         expect(dom.baseElement).toMatchSnapshot();
     });
@@ -109,9 +73,7 @@ describe('Rendering test', () => {
 describe('Error rendering test', () => {
     it('renders error correctly when open with error', () => {
         const dom = render(
-            <EditorContext.Provider value={mockEditorContextPublicationTrue}>
-                <SaveResultDialog mutation={mockErrorMutation} onClose={onCloseMock} open={true} />)
-            </EditorContext.Provider>
+                <SaveResultDialog mutation={mockErrorMutation} onClose={onCloseMock} open={true} />
         );
         expect(dom.baseElement).toMatchSnapshot();
     });
@@ -120,9 +82,7 @@ describe('Error rendering test', () => {
 describe('Assertion test', () => {
     it('invokes close function when cancel button is clicked', () => {
         render(
-            <EditorContext.Provider value={mockEditorContextPublicationTrue}>
                 <SaveResultDialog mutation={mockSuccessMutation} onClose={onCloseMock} open={true} />
-            </EditorContext.Provider>
         );
         fireEvent.click(screen.getByText('saveResultDialog.ok'));
         expect(onCloseMock).toHaveBeenCalledTimes(1);

--- a/PxGraf.Frontend/src/components/SaveResultDialog/__snapshots__/SaveResultDialog.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/SaveResultDialog/__snapshots__/SaveResultDialog.test.tsx.snap
@@ -6,9 +6,7 @@ exports[`Error rendering test renders error correctly when open with error 1`] =
 >
   <div
     aria-hidden="true"
-  >
-    )
-  </div>
+  />
   <div
     class="MuiDialog-root MuiModal-root css-1424xw8-MuiModal-root-MuiDialog-root"
     role="presentation"

--- a/PxGraf.Frontend/src/components/VariableSelection/DefaultSelectableDimensionSelection.test.tsx
+++ b/PxGraf.Frontend/src/components/VariableSelection/DefaultSelectableDimensionSelection.test.tsx
@@ -3,7 +3,7 @@ import { render } from "@testing-library/react";
 import { IDimensionValue } from "../../types/cubeMeta";
 import DefaultSelectableDimensionSelection from "./DefaultSelectableDimensionSelection";
 import UiLanguageContext from '../../contexts/uiLanguageContext';
-import { EditorContext } from 'contexts/editorContext';
+import { VisualizationContext } from 'contexts/visualizationContext';
 
 const mockDimensionValues: IDimensionValue[] = [
     {
@@ -71,13 +71,13 @@ describe('Rendering test', () => {
     it('renders correctly with default selectable', () => {
         const { asFragment } = render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{ cubeQuery, setCubeQuery, query, setQuery, saveDialogOpen, setSaveDialogOpen, selectedVisualizationUserInput, setSelectedVisualizationUserInput, visualizationSettingsUserInput, setVisualizationSettingsUserInput, defaultSelectables, setDefaultSelectables, loadedQueryId: '', setLoadedQueryId: jest.fn(), loadedQueryIsDraft: false, setLoadedQueryIsDraft: jest.fn(), publicationWebhookEnabled: true, setPublicationWebhookEnabled: jest.fn() }}>
+                <VisualizationContext.Provider value={{ defaultSelectables, setDefaultSelectables, selectedVisualizationUserInput, setSelectedVisualizationUserInput, visualizationSettingsUserInput, setVisualizationSettingsUserInput }}>
                     <DefaultSelectableDimensionSelection
                         options={mockDimensionValues}
                         resolvedDimensionValueCodes={mockResolvedCodes}
                         dimensionCode={'foo'}
                     />
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         expect(asFragment()).toMatchSnapshot();
     });
@@ -85,13 +85,13 @@ describe('Rendering test', () => {
     it('renders correctly without default selectable', () => {
         const { asFragment } = render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{ cubeQuery, setCubeQuery, query, setQuery, saveDialogOpen, setSaveDialogOpen, selectedVisualizationUserInput, setSelectedVisualizationUserInput, visualizationSettingsUserInput, setVisualizationSettingsUserInput, defaultSelectables: {}, setDefaultSelectables, loadedQueryId: '', setLoadedQueryId: jest.fn(), loadedQueryIsDraft: false, setLoadedQueryIsDraft: jest.fn(), publicationWebhookEnabled: true, setPublicationWebhookEnabled: jest.fn() }}>
+                <VisualizationContext.Provider value={{ defaultSelectables: {}, setDefaultSelectables, selectedVisualizationUserInput, setSelectedVisualizationUserInput, visualizationSettingsUserInput, setVisualizationSettingsUserInput }}>
                     <DefaultSelectableDimensionSelection
                         options={mockDimensionValues}
                         resolvedDimensionValueCodes={mockResolvedCodes}
                         dimensionCode={'foo'}
                     />
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         expect(asFragment()).toMatchSnapshot();
     });
@@ -99,13 +99,13 @@ describe('Rendering test', () => {
     it('renders correctly without resolved dimension value codes', () => {
         const { asFragment } = render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{ cubeQuery, setCubeQuery, query, setQuery, saveDialogOpen, setSaveDialogOpen, selectedVisualizationUserInput, setSelectedVisualizationUserInput, visualizationSettingsUserInput, setVisualizationSettingsUserInput, defaultSelectables, setDefaultSelectables, loadedQueryId: '', setLoadedQueryId: jest.fn(), loadedQueryIsDraft: false, setLoadedQueryIsDraft: jest.fn(), publicationWebhookEnabled: true, setPublicationWebhookEnabled: jest.fn() }}>
+                <VisualizationContext.Provider value={{ defaultSelectables, setDefaultSelectables, selectedVisualizationUserInput, setSelectedVisualizationUserInput, visualizationSettingsUserInput, setVisualizationSettingsUserInput }}>
                     <DefaultSelectableDimensionSelection
                         options={mockDimensionValues}
                         resolvedDimensionValueCodes={[]}
                         dimensionCode={'foo'}
                     />
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         expect(asFragment()).toMatchSnapshot();
     });

--- a/PxGraf.Frontend/src/components/VariableSelection/DefaultSelectableDimensionSelection.tsx
+++ b/PxGraf.Frontend/src/components/VariableSelection/DefaultSelectableDimensionSelection.tsx
@@ -4,7 +4,7 @@ import { UiLanguageContext } from 'contexts/uiLanguageContext';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { IDimensionValue } from 'types/cubeMeta';
-import { EditorContext } from 'contexts/editorContext';
+import { VisualizationContext } from 'contexts/visualizationContext';
 
 interface IDefaultSelectableDimensionSelection {
     dimensionCode: string;
@@ -21,7 +21,7 @@ const StyledAutocomplete = styled(Autocomplete)`
 
 export const DefaultSelectableDimensionSelection: React.FC<IDefaultSelectableDimensionSelection> = ({ dimensionCode, resolvedDimensionValueCodes, options }) => {
     const { language } = React.useContext(UiLanguageContext);
-    const { defaultSelectables, setDefaultSelectables } = React.useContext(EditorContext);
+    const { defaultSelectables, setDefaultSelectables } = React.useContext(VisualizationContext);
     const { t } = useTranslation();
 
     // Note: array filtering to support selecting multiple values in the future

--- a/PxGraf.Frontend/src/components/VariableSelection/DimensionSelection.tsx
+++ b/PxGraf.Frontend/src/components/VariableSelection/DimensionSelection.tsx
@@ -19,7 +19,7 @@ import styled from 'styled-components';
 import { IDimension } from 'types/cubeMeta';
 import { FilterType, IDimensionQuery, Query } from 'types/query';
 import DefaultSelectableDimensionSelection from './DefaultSelectableDimensionSelection';
-import { EditorContext } from '../../contexts/editorContext';
+import { QueryContext } from '../../contexts/queryContext';
 
 interface IDimensionSelectionProps {
     dimension: IDimension
@@ -40,7 +40,7 @@ const ComponentWrapper = styled(Stack)`
 export const DimensionSelection: React.FC<IDimensionSelectionProps> = ({ dimension, resolvedDimensionValueCodes, query }) => {
     const [anchorEl, setAnchorEl] = useState(null);
     const { t } = useTranslation();
-    const { setQuery } = React.useContext(EditorContext);
+    const { setQuery } = React.useContext(QueryContext);
     const dimensionQuery = query[dimension.code];
 
     const onQueryChanged = (newQuery: IDimensionQuery) => {
@@ -129,9 +129,9 @@ export const DimensionSelection: React.FC<IDimensionSelectionProps> = ({ dimensi
             </SelectorWrapper>
 
             {
-                dimensionQuery.valueFilter.type !== FilterType.Item ? (
+                dimensionQuery.valueFilter.type === FilterType.Item ? null : (
                     <ResultList dimensionValues={dimension.values} resolvedDimensionValueCodes={resolvedDimensionValueCodes} />
-                ) : null
+                )
             }
 
             <SelectabilitySwitch onChange={value => onChangeMUIWrapper({ ...dimensionQuery, selectable: value })} selected={dimensionQuery.selectable} />

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/MultiselectableSelector.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/MultiselectableSelector.tsx
@@ -4,7 +4,7 @@ import { IVisualizationSettingsProps } from '../VisualizationSettingsControl';
 import { IDimension } from "types/cubeMeta";
 import { UiLanguageContext } from 'contexts/uiLanguageContext';
 import { useTranslation } from 'react-i18next';
-import { EditorContext } from '../../../contexts/editorContext';
+import { VisualizationContext } from '../../../contexts/visualizationContext';
 
 interface IMultiselectableSelectorProps extends IVisualizationSettingsProps {
     dimensions: IDimension[]
@@ -13,7 +13,7 @@ interface IMultiselectableSelectorProps extends IVisualizationSettingsProps {
 export const MultiselectableSelector: React.FC<IMultiselectableSelectorProps> = ({ visualizationSettings, dimensions  }) => {
     const { t } = useTranslation();
     const { language, languageTab } = React.useContext(UiLanguageContext);
-    const { setVisualizationSettingsUserInput } = React.useContext(EditorContext);
+    const { setVisualizationSettingsUserInput } = React.useContext(VisualizationContext);
 
     return (
         <FormControl>

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/TablePivotSettings.test.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/TablePivotSettings.test.tsx
@@ -6,7 +6,7 @@ import UiLanguageContext from 'contexts/uiLanguageContext';
 import { Query, FilterType } from "types/query";
 import '@testing-library/jest-dom';
 import { IVisualizationSettings } from '../../../types/visualizationSettings';
-import { EditorContext } from '../../../contexts/editorContext';
+import { VisualizationContext } from '../../../contexts/visualizationContext';
 import { VisualizationType } from '../../../types/visualizationType';
 import { IVisualizationOptions } from '../../../types/editorContentsResponse';
 
@@ -207,25 +207,13 @@ describe('Assertion tests', () => {
         const mockSettingsChangedHandler = jest.fn();
         render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
+                <VisualizationContext.Provider value={{
                     defaultSelectables,
                     setDefaultSelectables,
-                    cubeQuery,
-                    setCubeQuery,
-                    query,
-                    setQuery,
-                    saveDialogOpen,
-                    setSaveDialogOpen,
                     selectedVisualizationUserInput,
                     setSelectedVisualizationUserInput,
                     visualizationSettingsUserInput,
                     setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
 
                 }}>
                     <TablePivotSettings
@@ -234,7 +222,7 @@ describe('Assertion tests', () => {
                         visualizationSettings={mockVisualizationSettings}
                         query={mockQuery}
                     ></TablePivotSettings>
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         fireEvent.click(screen.getByText('foo3 2'));
         fireEvent.click(screen.getAllByText((_content, element) => element.tagName.toLowerCase() === 'button')[0]);
@@ -247,25 +235,13 @@ describe('Assertion tests', () => {
         const mockSettingsChangedHandler = jest.fn();
         render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
+                <VisualizationContext.Provider value={{
                     defaultSelectables,
                     setDefaultSelectables,
-                    cubeQuery,
-                    setCubeQuery,
-                    query,
-                    setQuery,
-                    saveDialogOpen,
-                    setSaveDialogOpen,
                     selectedVisualizationUserInput,
                     setSelectedVisualizationUserInput,
                     visualizationSettingsUserInput,
                     setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <TablePivotSettings
                         dimensions={mockDimensions}
@@ -273,7 +249,7 @@ describe('Assertion tests', () => {
                         visualizationSettings={mockVisualizationSettings}
                         query={mockQuery}
                     ></TablePivotSettings>
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         fireEvent.click(screen.getByText('foo4 2'));
         fireEvent.click(screen.getAllByText((_content, element) => element.tagName.toLowerCase() === 'button')[0]);
@@ -286,25 +262,13 @@ describe('Assertion tests', () => {
         const mockSettingsChangedHandler = jest.fn();
         render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
+                <VisualizationContext.Provider value={{
                     defaultSelectables,
                     setDefaultSelectables,
-                    cubeQuery,
-                    setCubeQuery,
-                    query,
-                    setQuery,
-                    saveDialogOpen,
-                    setSaveDialogOpen,
                     selectedVisualizationUserInput,
                     setSelectedVisualizationUserInput,
                     visualizationSettingsUserInput,
                     setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <TablePivotSettings
                         dimensions={mockDimensions}
@@ -312,7 +276,7 @@ describe('Assertion tests', () => {
                         visualizationSettings={mockVisualizationSettings}
                         query={mockQuery}
                     ></TablePivotSettings>
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         fireEvent.click(screen.getByText('foo1 2'));
         fireEvent.click(screen.getAllByText((_content, element) => element.tagName.toLowerCase() === 'button')[1]);
@@ -325,25 +289,13 @@ describe('Assertion tests', () => {
         const mockSettingsChangedHandler = jest.fn();
         render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
+                <VisualizationContext.Provider value={{
                     defaultSelectables,
                     setDefaultSelectables,
-                    cubeQuery,
-                    setCubeQuery,
-                    query,
-                    setQuery,
-                    saveDialogOpen,
-                    setSaveDialogOpen,
                     selectedVisualizationUserInput,
                     setSelectedVisualizationUserInput,
                     visualizationSettingsUserInput,
                     setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <TablePivotSettings
                         dimensions={mockDimensions}
@@ -351,7 +303,7 @@ describe('Assertion tests', () => {
                         visualizationSettings={mockVisualizationSettings}
                         query={mockQuery}
                     ></TablePivotSettings>
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         fireEvent.click(screen.getByText('foo2 2'));
         fireEvent.click(screen.getAllByText((_content, element) => element.tagName.toLowerCase() === 'button')[1]);
@@ -364,25 +316,13 @@ describe('Assertion tests', () => {
         const mockSettingsChangedHandler = jest.fn();
         render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
+                <VisualizationContext.Provider value={{
                     defaultSelectables,
                     setDefaultSelectables,
-                    cubeQuery,
-                    setCubeQuery,
-                    query,
-                    setQuery,
-                    saveDialogOpen,
-                    setSaveDialogOpen,
                     selectedVisualizationUserInput,
                     setSelectedVisualizationUserInput,
                     visualizationSettingsUserInput,
                     setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <TablePivotSettings
                         dimensions={mockDimensions}
@@ -390,7 +330,7 @@ describe('Assertion tests', () => {
                         visualizationSettings={mockVisualizationSettings}
                         query={mockQuery}
                     ></TablePivotSettings>
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         fireEvent.click(screen.getByText('foo3 2'));
         fireEvent.click(screen.getAllByText((_content, element) => element.tagName.toLowerCase() === 'button')[2]);
@@ -403,25 +343,13 @@ describe('Assertion tests', () => {
         const mockSettingsChangedHandler = jest.fn();
         render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
+                <VisualizationContext.Provider value={{
                     defaultSelectables,
                     setDefaultSelectables,
-                    cubeQuery,
-                    setCubeQuery,
-                    query,
-                    setQuery,
-                    saveDialogOpen,
-                    setSaveDialogOpen,
                     selectedVisualizationUserInput,
                     setSelectedVisualizationUserInput,
                     visualizationSettingsUserInput,
                     setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <TablePivotSettings
                         dimensions={mockDimensions}
@@ -429,7 +357,7 @@ describe('Assertion tests', () => {
                         visualizationSettings={mockVisualizationSettings}
                         query={mockQuery}
                     ></TablePivotSettings>
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         fireEvent.click(screen.getByText('foo4 2'));
         fireEvent.click(screen.getAllByText((_content, element) => element.tagName.toLowerCase() === 'button')[2]);
@@ -442,25 +370,13 @@ describe('Assertion tests', () => {
         const mockSettingsChangedHandler = jest.fn();
         render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
+                <VisualizationContext.Provider value={{
                     defaultSelectables,
                     setDefaultSelectables,
-                    cubeQuery,
-                    setCubeQuery,
-                    query,
-                    setQuery,
-                    saveDialogOpen,
-                    setSaveDialogOpen,
                     selectedVisualizationUserInput,
                     setSelectedVisualizationUserInput,
                     visualizationSettingsUserInput,
                     setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <TablePivotSettings
                         dimensions={mockDimensions}
@@ -468,7 +384,7 @@ describe('Assertion tests', () => {
                         visualizationSettings={mockVisualizationSettings}
                         query={mockQuery}
                     ></TablePivotSettings>
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         fireEvent.click(screen.getAllByText((_content, element) => element.tagName.toLowerCase() === 'button')[0]);
         await waitFor(() => {
@@ -481,25 +397,13 @@ describe('Assertion tests', () => {
         const toggledMockSettings = { ...mockVisualizationSettings, cutYAxis: true }
         render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
+                <VisualizationContext.Provider value={{
                     defaultSelectables,
                     setDefaultSelectables,
-                    cubeQuery,
-                    setCubeQuery,
-                    query,
-                    setQuery,
-                    saveDialogOpen,
-                    setSaveDialogOpen,
                     selectedVisualizationUserInput,
                     setSelectedVisualizationUserInput,
                     visualizationSettingsUserInput,
                     setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <TablePivotSettings
                         dimensions={mockDimensions}
@@ -507,7 +411,7 @@ describe('Assertion tests', () => {
                         visualizationSettings={toggledMockSettings}
                         query={mockQuery}
                     ></TablePivotSettings>
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         expect(screen.getByText('chartSettings.columnVariables').parentElement).toContainElement(screen.getByText("foo2 2"));
     });
@@ -517,25 +421,13 @@ describe('Assertion tests', () => {
         const toggledMockSettings = { ...mockVisualizationSettings, cutYAxis: true }
         render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
+                <VisualizationContext.Provider value={{
                     defaultSelectables,
                     setDefaultSelectables,
-                    cubeQuery,
-                    setCubeQuery,
-                    query,
-                    setQuery,
-                    saveDialogOpen,
-                    setSaveDialogOpen,
                     selectedVisualizationUserInput,
                     setSelectedVisualizationUserInput,
                     visualizationSettingsUserInput,
                     setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <TablePivotSettings
                         dimensions={mockDimensions}
@@ -543,7 +435,7 @@ describe('Assertion tests', () => {
                         visualizationSettings={toggledMockSettings}
                         query={mockQuery}
                     ></TablePivotSettings>
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         expect(screen.getByText('chartSettings.rowVariables').parentElement).toContainElement(screen.getByText("foo1 2"));
     });
@@ -553,25 +445,13 @@ describe('Assertion tests', () => {
         const toggledMockSettings = { ...mockVisualizationSettings, columnVariableCodes: ["foobar2", "foobar5"] }
         render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
+                <VisualizationContext.Provider value={{
                     defaultSelectables,
                     setDefaultSelectables,
-                    cubeQuery,
-                    setCubeQuery,
-                    query,
-                    setQuery,
-                    saveDialogOpen,
-                    setSaveDialogOpen,
                     selectedVisualizationUserInput,
                     setSelectedVisualizationUserInput,
                     visualizationSettingsUserInput,
                     setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <TablePivotSettings
                         dimensions={mockDimensions}
@@ -579,7 +459,7 @@ describe('Assertion tests', () => {
                         visualizationSettings={toggledMockSettings}
                         query={mockQuery}
                     ></TablePivotSettings>
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         expect(screen.getByText('chartSettings.columnVariables').parentElement).toHaveTextContent("foo2 2");
         expect(screen.getByText('chartSettings.columnVariables').parentElement).not.toHaveTextContent("foo5 1");
@@ -589,25 +469,13 @@ describe('Assertion tests', () => {
         const mockSettingsChangedHandler = jest.fn();
         render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
+                <VisualizationContext.Provider value={{
                     defaultSelectables,
                     setDefaultSelectables,
-                    cubeQuery,
-                    setCubeQuery,
-                    query,
-                    setQuery,
-                    saveDialogOpen,
-                    setSaveDialogOpen,
                     selectedVisualizationUserInput,
                     setSelectedVisualizationUserInput,
                     visualizationSettingsUserInput,
                     setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <TablePivotSettings
                         dimensions={mockDimensions}
@@ -616,7 +484,7 @@ describe('Assertion tests', () => {
                         selectableDimensions={[mockDimensions[1]]}
                         query={mockQuery}
                     ></TablePivotSettings>
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         expect(screen.getByText('chartSettings.columnVariables').parentElement).not.toHaveTextContent("foo2 2");
     });
@@ -627,25 +495,13 @@ describe('Assertion tests', () => {
         const mockQueryWithPotentiallyGrowingVariable = { ...mockQuery, foobar5: { ...mockQuery.foobar5, valueFilter: { type: FilterType.All } } }
         render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
+                <VisualizationContext.Provider value={{
                     defaultSelectables,
                     setDefaultSelectables,
-                    cubeQuery,
-                    setCubeQuery,
-                    query,
-                    setQuery,
-                    saveDialogOpen,
-                    setSaveDialogOpen,
                     selectedVisualizationUserInput,
                     setSelectedVisualizationUserInput,
                     visualizationSettingsUserInput,
                     setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <TablePivotSettings
                         dimensions={mockDimensions}
@@ -653,7 +509,7 @@ describe('Assertion tests', () => {
                         visualizationSettings={toggledMockSettings}
                         query={mockQueryWithPotentiallyGrowingVariable}
                     ></TablePivotSettings>
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         expect(screen.getByText('chartSettings.columnVariables').parentElement).toHaveTextContent("foo2 2");
         expect(screen.getByText('chartSettings.columnVariables').parentElement).toHaveTextContent("foo5 1");
@@ -665,25 +521,13 @@ describe('Assertion tests', () => {
         const multiselectableVisualizatioRules = { ...mockVisualizationRules, multiselectVariableAllowed: true };
         render(
             <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                <EditorContext.Provider value={{
+                <VisualizationContext.Provider value={{
                     defaultSelectables,
                     setDefaultSelectables,
-                    cubeQuery,
-                    setCubeQuery,
-                    query,
-                    setQuery,
-                    saveDialogOpen,
-                    setSaveDialogOpen,
                     selectedVisualizationUserInput,
                     setSelectedVisualizationUserInput,
                     visualizationSettingsUserInput,
                     setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                    loadedQueryId: '',
-                    setLoadedQueryId: jest.fn(),
-                    loadedQueryIsDraft: false,
-                    setLoadedQueryIsDraft: jest.fn(),
-                    publicationWebhookEnabled: true,
-                    setPublicationWebhookEnabled: jest.fn()
                 }}>
                     <TablePivotSettings
                         dimensions={mockDimensions}
@@ -691,7 +535,7 @@ describe('Assertion tests', () => {
                         visualizationSettings={multiselectableMockSettings}
                         query={mockQuery}
                     ></TablePivotSettings>
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>);
         expect(screen.getByText('chartSettings.columnVariables').parentElement).toHaveTextContent("foo2 2");
     });

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/TablePivotSettings.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/TablePivotSettings.tsx
@@ -9,7 +9,7 @@ import { IVisualizationSettingsProps } from '../VisualizationSettingsControl';
 import { IDimension } from 'types/cubeMeta';
 import styled from 'styled-components';
 import { Query } from "types/query";
-import { EditorContext } from '../../../contexts/editorContext';
+import { VisualizationContext } from '../../../contexts/visualizationContext';
 
 const DimensionListWrapper = styled(Stack)`
     padding: 8px;
@@ -30,7 +30,7 @@ interface ITableSettingsProps extends IVisualizationSettingsProps {
 export const TablePivotSettings: React.FC<ITableSettingsProps> = ({ visualizationSettings, dimensions, selectableDimensions, query }) => {
     const { t } = useTranslation();
     const [selected, setSelected] = useState("");
-    const { setVisualizationSettingsUserInput } = React.useContext(EditorContext);
+    const { setVisualizationSettingsUserInput } = React.useContext(VisualizationContext);
 
     const upHandler = () => {
         if (selected == null) return;

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/MarkerScaler.test.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/MarkerScaler.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import MarkerScaler from "./MarkerScaler";
 import { IVisualizationSettings } from '../../../types/visualizationSettings';
-import { EditorContext } from '../../../contexts/editorContext';
+import { VisualizationContext } from '../../../contexts/visualizationContext';
 import { VisualizationType } from '../../../types/visualizationType';
 import { IVisualizationOptions } from '../../../types/editorContentsResponse';
 
@@ -50,31 +50,19 @@ describe('Assertion tests', () => {
     it('MarkerScaler onChange and onChangeCommitted should work properly', () => {
         const mockSettingsChangedHandler = jest.fn();
         render(
-            <EditorContext.Provider value={{
+            <VisualizationContext.Provider value={{
                 defaultSelectables: {},
                 setDefaultSelectables: jest.fn(),
-                cubeQuery: null,
-                setCubeQuery: jest.fn(),
-                query: {},
-                setQuery: jest.fn(),
-                saveDialogOpen: false,
-                setSaveDialogOpen: jest.fn(),
                 selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
                 setSelectedVisualizationUserInput: jest.fn(),
                 visualizationSettingsUserInput: {},
                 setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                loadedQueryId: '',
-                setLoadedQueryId: jest.fn(),
-                loadedQueryIsDraft: false,
-                setLoadedQueryIsDraft: jest.fn(),
-                publicationWebhookEnabled: true,
-                setPublicationWebhookEnabled: jest.fn()
             }}>
                 <MarkerScaler
                     visualizationOptions={mockVisualizationRules}
                     visualizationSettings={mockVisualizationSettings}
                 />
-            </EditorContext.Provider>
+            </VisualizationContext.Provider>
         );
 
         const slider = screen.getByRole('slider');

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/MarkerScaler.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/MarkerScaler.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { IVisualizationSettingsProps } from '../VisualizationSettingsControl';
 import styled from 'styled-components';
-import { EditorContext } from '../../../contexts/editorContext';
+import { VisualizationContext } from '../../../contexts/visualizationContext';
 
 const FormControlWrapper = styled(Stack)`
     gap: 40px;
@@ -19,7 +19,7 @@ export const MarkerScaler: React.FC<IVisualizationSettingsProps> = ({ visualizat
     const { t } = useTranslation();
     // We dont want to trigger the api call every time the slider moves, only when the change is committed.
     const [sliderValue, setSliderValue] = React.useState(visualizationSettings.markerSize);
-    const { setVisualizationSettingsUserInput } = React.useContext(EditorContext);
+    const { setVisualizationSettingsUserInput } = React.useContext(VisualizationContext);
 
     const marks = [
         {

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/SortingSelector.test.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/SortingSelector.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import { ISortingOption } from "../../../types/editorContentsResponse";
 import { IVisualizationSettings } from "../../../types/visualizationSettings";
 import UiLanguageContext from '../../../contexts/uiLanguageContext';
-import { EditorContext } from '../../../contexts/editorContext';
+import { VisualizationContext } from '../../../contexts/visualizationContext';
 import React from 'react';
 import SortingSelector from './SortingSelector';
 import userEvent from '@testing-library/user-event';
@@ -42,33 +42,21 @@ const languageContext =
 };
 
 const editorContext = {
-    cubeQuery: null,
-    setCubeQuery: jest.fn(),
-    query: null,
-    setQuery: jest.fn(),
-    saveDialogOpen: false,
-    setSaveDialogOpen: jest.fn(),
     selectedVisualizationUserInput: null,
     setSelectedVisualizationUserInput: jest.fn(),
     visualizationSettingsUserInput: null,
     setVisualizationSettingsUserInput: jest.fn(),
     defaultSelectables: null,
     setDefaultSelectables: jest.fn(),
-    loadedQueryId: '',
-    setLoadedQueryId: jest.fn(),
-    loadedQueryIsDraft: false,
-    setLoadedQueryIsDraft: jest.fn(),
-    publicationWebhookEnabled: true,
-    setPublicationWebhookEnabled: jest.fn()
 };
 
 describe('rendering test', () => {
     it('renders sorting selector correctly', () => {
         const { asFragment } = render(
             <UiLanguageContext.Provider value={languageContext}>
-                <EditorContext.Provider value={editorContext}>
+                <VisualizationContext.Provider value={editorContext}>
                     <SortingSelector visualizationSettings={visualizationSettings} sortingOptions={sortingOptions} />
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>
         );
 
@@ -82,9 +70,9 @@ describe('functionality test', () => {
         const mockSetVisualizationSettingsUserInput = jest.fn();
         const { getByLabelText, getByText } = render(
             <UiLanguageContext.Provider value={languageContext}>
-                <EditorContext.Provider value={{ ...editorContext, setVisualizationSettingsUserInput: mockSetVisualizationSettingsUserInput }}>
+                <VisualizationContext.Provider value={{ ...editorContext, setVisualizationSettingsUserInput: mockSetVisualizationSettingsUserInput }}>
                     <SortingSelector visualizationSettings={visualizationSettings} sortingOptions={sortingOptions} />
-                </EditorContext.Provider>
+                </VisualizationContext.Provider>
             </UiLanguageContext.Provider>
         );
         const sortingSelector = getByLabelText('chartSettings.sort');

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/SortingSelector.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/SortingSelector.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { UiLanguageContext } from 'contexts/uiLanguageContext';
 import { IVisualizationSettings } from '../../../types/visualizationSettings';
-import { EditorContext } from '../../../contexts/editorContext';
+import { VisualizationContext } from '../../../contexts/visualizationContext';
 import { ISortingOption } from '../../../types/editorContentsResponse';
 
 interface ISortingSelectorProps {
@@ -16,7 +16,7 @@ interface ISortingSelectorProps {
 export const SortingSelector: React.FC<ISortingSelectorProps> = ({ sortingOptions, visualizationSettings }) => {
     const { t } = useTranslation();
     const { uiContentLanguage } = React.useContext(UiLanguageContext);
-    const { setVisualizationSettingsUserInput } = React.useContext(EditorContext);
+    const { setVisualizationSettingsUserInput } = React.useContext(VisualizationContext);
 
     return (
         <FormControl>

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/VisualizationSettingsSwitch.test.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/VisualizationSettingsSwitch.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from "@testing-library/react";
 import VisualizationSettingsSwitch from "./VisualizationSettingsSwitch";
-import { EditorContext } from '../../../contexts/editorContext';
+import { VisualizationContext } from '../../../contexts/visualizationContext';
 import { VisualizationType } from '../../../types/visualizationType';
 
 const mockSettingsChangedHandler = jest.fn();
@@ -23,25 +23,13 @@ describe('Rendering test', () => {
 describe('Assertion tests', () => {
     it('calls settingsChangedHandler with correct value when clicked', () => {
         const { getByRole } = render(
-            <EditorContext.Provider value={{
+            <VisualizationContext.Provider value={{
                 defaultSelectables: {},
                 setDefaultSelectables: jest.fn(),
-                cubeQuery: null,
-                setCubeQuery: jest.fn(),
-                query: {},
-                setQuery: jest.fn(),
-                saveDialogOpen: false,
-                setSaveDialogOpen: jest.fn(),
                 selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
                 setSelectedVisualizationUserInput: jest.fn(),
                 visualizationSettingsUserInput: {},
                 setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                loadedQueryId: '',
-                setLoadedQueryId: jest.fn(),
-                loadedQueryIsDraft: false,
-                setLoadedQueryIsDraft: jest.fn(),
-                publicationWebhookEnabled: true,
-                setPublicationWebhookEnabled: jest.fn()
             }}>
                 <VisualizationSettingsSwitch
                     selected={false}
@@ -49,7 +37,7 @@ describe('Assertion tests', () => {
                     label={"label"}
                     changeProperty={"showDataPoints"}
                 />
-            </EditorContext.Provider>);
+            </VisualizationContext.Provider>);
         const switchElement = getByRole('switch');
         fireEvent.click(switchElement);
 

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/VisualizationSettingsSwitch.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/VisualizationSettingsSwitch.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { FormControlLabel, FormControl, Switch, Typography } from '@mui/material';
 import { IVisualizationSettings } from "types/visualizationSettings";
 import styled from "styled-components";
-import { EditorContext } from '../../../contexts/editorContext';
+import { VisualizationContext } from '../../../contexts/visualizationContext';
 
 const HiddenFormControl = styled(FormControl)`
     display: none !important;
@@ -25,7 +25,7 @@ interface IVisualizationSettingsSwitchProps {
 export const VisualizationSettingsSwitch: React.FC<IVisualizationSettingsSwitchProps> = ({ selected, visualizationSettings, label, changeProperty, hidden }) => {
     const { t } = useTranslation();
     const Control = hidden ? HiddenFormControl : FormControl;
-    const { setVisualizationSettingsUserInput } = React.useContext(EditorContext);
+    const { setVisualizationSettingsUserInput } = React.useContext(VisualizationContext);
 
     return (
         <Control fullWidth>

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/VisualizationSettingsControl.test.tsx
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/VisualizationSettingsControl.test.tsx
@@ -5,7 +5,7 @@ import { IDimension, EDimensionType } from "types/cubeMeta";
 import VisualizationSettingControl from "./VisualizationSettingsControl";
 import { FilterType, Query } from "types/query";
 import { IVisualizationSettings } from '../../types/visualizationSettings';
-import { EditorContext } from '../../contexts/editorContext';
+import { VisualizationContext } from '../../contexts/visualizationContext';
 import { VisualizationType } from '../../types/visualizationType';
 import { IVisualizationOptions } from '../../types/editorContentsResponse';
 
@@ -305,25 +305,13 @@ describe('Assertion tests', () => {
 
     it('updates values properly when user changes switches', () => {
         const { getByLabelText } = render(
-            <EditorContext.Provider value={{
+            <VisualizationContext.Provider value={{
                 defaultSelectables: {},
                 setDefaultSelectables: jest.fn(),
-                cubeQuery: null,
-                setCubeQuery: jest.fn(),
-                query: {},
-                setQuery: jest.fn(),
-                saveDialogOpen: false,
-                setSaveDialogOpen: jest.fn(),
                 selectedVisualizationUserInput: VisualizationType.VerticalBarChart,
                 setSelectedVisualizationUserInput: jest.fn(),
                 visualizationSettingsUserInput: {},
                 setVisualizationSettingsUserInput: mockSettingsChangedHandler,
-                loadedQueryId: '',
-                setLoadedQueryId: jest.fn(),
-                loadedQueryIsDraft: false,
-                setLoadedQueryIsDraft: jest.fn(),
-                publicationWebhookEnabled: true,
-                setPublicationWebhookEnabled: jest.fn()
             }}>
                 <VisualizationSettingControl
                     selectedVisualization={VisualizationType.Table}
@@ -332,7 +320,7 @@ describe('Assertion tests', () => {
                     visualizationOptions={mockVisualizationRules}
                     visualizationSettings={mockVisualizationSettings}
                 />
-            </EditorContext.Provider>
+            </VisualizationContext.Provider>
         );
 
         fireEvent.click(getByLabelText('visualizationSettings.showDataPoints'));

--- a/PxGraf.Frontend/src/contexts/__tests__/queryContext.test.tsx
+++ b/PxGraf.Frontend/src/contexts/__tests__/queryContext.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { QueryContext, QueryProvider } from 'contexts/queryContext';
+import { act, render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FilterType } from 'types/query';
+
+const TestComponent = () => {
+    const { cubeQuery, setCubeQuery, query, setQuery } = React.useContext(QueryContext);
+
+    return (
+        <>
+            <div data-testid="cubeQuery">{JSON.stringify(cubeQuery)}</div>
+            <div data-testid="query">{query ? JSON.stringify(query) : 'null'}</div>
+            <button
+                data-testid="setCubeQuery"
+                onClick={() => setCubeQuery({ chartHeaderEdit: { fi: 'Testi' }, variableQueries: { dim1: { valueEdits: {} } } })}
+            />
+            <button
+                data-testid="setQuery"
+                onClick={() => setQuery({ dim1: { valueFilter: { type: FilterType.Item, query: ['val1'] }, selectable: false, virtualValueDefinitions: null } })}
+            />
+        </>
+    );
+};
+
+describe('QueryContext', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('should have default values initially', () => {
+        const { getByTestId } = render(
+            <QueryProvider><TestComponent /></QueryProvider>
+        );
+        expect(getByTestId('cubeQuery')).toHaveTextContent('{"variableQueries":{}}');
+        expect(getByTestId('query')).toHaveTextContent('null');
+    });
+
+    it('should update query immediately', () => {
+        const { getByTestId } = render(
+            <QueryProvider><TestComponent /></QueryProvider>
+        );
+
+        act(() => {
+            getByTestId('setQuery').click();
+        });
+
+        expect(getByTestId('query')).toHaveTextContent('"dim1"');
+        expect(getByTestId('query')).toHaveTextContent('"item"');
+    });
+
+    it('should debounce cubeQuery updates', async () => {
+        const { getByTestId } = render(
+            <QueryProvider><TestComponent /></QueryProvider>
+        );
+
+        act(() => {
+            getByTestId('setCubeQuery').click();
+        });
+
+        // Should still show the initial value before debounce fires
+        expect(getByTestId('cubeQuery')).toHaveTextContent('{"variableQueries":{}}');
+
+        // Advance timers past the 1000ms debounce
+        act(() => {
+            jest.advanceTimersByTime(1000);
+        });
+
+        await waitFor(() => {
+            expect(getByTestId('cubeQuery')).toHaveTextContent('"dim1"');
+            expect(getByTestId('cubeQuery')).toHaveTextContent('"Testi"');
+        });
+    });
+
+    it('should only apply the last cubeQuery when called rapidly', async () => {
+        let setCubeQueryRef: (q: any) => void;
+
+        const CapturingComponent = () => {
+            const { cubeQuery, setCubeQuery } = React.useContext(QueryContext);
+            setCubeQueryRef = setCubeQuery;
+            return <div data-testid="cubeQuery">{JSON.stringify(cubeQuery)}</div>;
+        };
+
+        const { getByTestId } = render(
+            <QueryProvider><CapturingComponent /></QueryProvider>
+        );
+
+        // Fire multiple updates within the debounce window
+        act(() => {
+            setCubeQueryRef({ variableQueries: { first: { valueEdits: {} } } });
+        });
+        act(() => {
+            setCubeQueryRef({ variableQueries: { second: { valueEdits: {} } } });
+        });
+        act(() => {
+            setCubeQueryRef({ variableQueries: { third: { valueEdits: {} } } });
+        });
+
+        act(() => {
+            jest.advanceTimersByTime(1000);
+        });
+
+        await waitFor(() => {
+            expect(getByTestId('cubeQuery')).toHaveTextContent('"third"');
+            expect(getByTestId('cubeQuery')).not.toHaveTextContent('"first"');
+            expect(getByTestId('cubeQuery')).not.toHaveTextContent('"second"');
+        });
+    });
+});

--- a/PxGraf.Frontend/src/contexts/__tests__/saveContext.test.tsx
+++ b/PxGraf.Frontend/src/contexts/__tests__/saveContext.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { SaveContext, SaveProvider } from 'contexts/saveContext';
+import { act, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const TestComponent = () => {
+    const {
+        saveDialogOpen, setSaveDialogOpen,
+        loadedQueryId, setLoadedQueryId,
+        loadedQueryIsDraft, setLoadedQueryIsDraft,
+        publicationWebhookEnabled, setPublicationWebhookEnabled,
+    } = React.useContext(SaveContext);
+
+    return (
+        <>
+            <div data-testid="dialogOpen">{String(saveDialogOpen)}</div>
+            <div data-testid="queryId">{loadedQueryId || 'empty'}</div>
+            <div data-testid="isDraft">{String(loadedQueryIsDraft)}</div>
+            <div data-testid="webhookEnabled">{String(publicationWebhookEnabled)}</div>
+            <button data-testid="openDialog" onClick={() => setSaveDialogOpen(true)} />
+            <button data-testid="setQueryId" onClick={() => setLoadedQueryId('query-123')} />
+            <button data-testid="setDraft" onClick={() => setLoadedQueryIsDraft(true)} />
+            <button data-testid="disableWebhook" onClick={() => setPublicationWebhookEnabled(false)} />
+        </>
+    );
+};
+
+describe('SaveContext', () => {
+    it('should have correct default values', () => {
+        const { getByTestId } = render(
+            <SaveProvider><TestComponent /></SaveProvider>
+        );
+        expect(getByTestId('dialogOpen')).toHaveTextContent('false');
+        expect(getByTestId('queryId')).toHaveTextContent('empty');
+        expect(getByTestId('isDraft')).toHaveTextContent('false');
+        expect(getByTestId('webhookEnabled')).toHaveTextContent('true');
+    });
+
+    it('should update saveDialogOpen', () => {
+        const { getByTestId } = render(
+            <SaveProvider><TestComponent /></SaveProvider>
+        );
+
+        act(() => {
+            getByTestId('openDialog').click();
+        });
+
+        expect(getByTestId('dialogOpen')).toHaveTextContent('true');
+    });
+
+    it('should update loadedQueryId', () => {
+        const { getByTestId } = render(
+            <SaveProvider><TestComponent /></SaveProvider>
+        );
+
+        act(() => {
+            getByTestId('setQueryId').click();
+        });
+
+        expect(getByTestId('queryId')).toHaveTextContent('query-123');
+    });
+
+    it('should update loadedQueryIsDraft', () => {
+        const { getByTestId } = render(
+            <SaveProvider><TestComponent /></SaveProvider>
+        );
+
+        act(() => {
+            getByTestId('setDraft').click();
+        });
+
+        expect(getByTestId('isDraft')).toHaveTextContent('true');
+    });
+
+    it('should update publicationWebhookEnabled', () => {
+        const { getByTestId } = render(
+            <SaveProvider><TestComponent /></SaveProvider>
+        );
+
+        act(() => {
+            getByTestId('disableWebhook').click();
+        });
+
+        expect(getByTestId('webhookEnabled')).toHaveTextContent('false');
+    });
+
+    it('should handle multiple state updates independently', () => {
+        const { getByTestId } = render(
+            <SaveProvider><TestComponent /></SaveProvider>
+        );
+
+        act(() => {
+            getByTestId('openDialog').click();
+            getByTestId('setQueryId').click();
+        });
+
+        expect(getByTestId('dialogOpen')).toHaveTextContent('true');
+        expect(getByTestId('queryId')).toHaveTextContent('query-123');
+        // Unchanged values remain at defaults
+        expect(getByTestId('isDraft')).toHaveTextContent('false');
+        expect(getByTestId('webhookEnabled')).toHaveTextContent('true');
+    });
+});

--- a/PxGraf.Frontend/src/contexts/__tests__/visualizationContext.test.tsx
+++ b/PxGraf.Frontend/src/contexts/__tests__/visualizationContext.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { VisualizationContext, VisualizationProvider } from 'contexts/visualizationContext';
+import { act, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { VisualizationType } from 'types/visualizationType';
+
+const TestComponent = () => {
+    const {
+        selectedVisualizationUserInput, setSelectedVisualizationUserInput,
+        visualizationSettingsUserInput, setVisualizationSettingsUserInput,
+        defaultSelectables, setDefaultSelectables,
+    } = React.useContext(VisualizationContext);
+
+    return (
+        <>
+            <div data-testid="visualization">{selectedVisualizationUserInput ?? 'null'}</div>
+            <div data-testid="settings">{visualizationSettingsUserInput ? JSON.stringify(visualizationSettingsUserInput) : 'null'}</div>
+            <div data-testid="selectables">{defaultSelectables ? JSON.stringify(defaultSelectables) : 'null'}</div>
+            <button
+                data-testid="setVisualization"
+                onClick={() => setSelectedVisualizationUserInput(VisualizationType.LineChart)}
+            />
+            <button
+                data-testid="setSettings"
+                onClick={() => setVisualizationSettingsUserInput({ cutYAxis: true, showDataPoints: false })}
+            />
+            <button
+                data-testid="setSelectables"
+                onClick={() => setDefaultSelectables({ dim1: ['val1', 'val2'] })}
+            />
+        </>
+    );
+};
+
+describe('VisualizationContext', () => {
+    it('should have null values initially', () => {
+        const { getByTestId } = render(
+            <VisualizationProvider><TestComponent /></VisualizationProvider>
+        );
+        expect(getByTestId('visualization')).toHaveTextContent('null');
+        expect(getByTestId('settings')).toHaveTextContent('null');
+        expect(getByTestId('selectables')).toHaveTextContent('null');
+    });
+
+    it('should update selectedVisualizationUserInput', () => {
+        const { getByTestId } = render(
+            <VisualizationProvider><TestComponent /></VisualizationProvider>
+        );
+
+        act(() => {
+            getByTestId('setVisualization').click();
+        });
+
+        expect(getByTestId('visualization')).toHaveTextContent('LineChart');
+    });
+
+    it('should update visualizationSettingsUserInput', () => {
+        const { getByTestId } = render(
+            <VisualizationProvider><TestComponent /></VisualizationProvider>
+        );
+
+        act(() => {
+            getByTestId('setSettings').click();
+        });
+
+        expect(getByTestId('settings')).toHaveTextContent('"cutYAxis":true');
+        expect(getByTestId('settings')).toHaveTextContent('"showDataPoints":false');
+    });
+
+    it('should update defaultSelectables', () => {
+        const { getByTestId } = render(
+            <VisualizationProvider><TestComponent /></VisualizationProvider>
+        );
+
+        act(() => {
+            getByTestId('setSelectables').click();
+        });
+
+        expect(getByTestId('selectables')).toHaveTextContent('"dim1"');
+        expect(getByTestId('selectables')).toHaveTextContent('"val1"');
+    });
+
+    it('should handle multiple state updates independently', () => {
+        const { getByTestId } = render(
+            <VisualizationProvider><TestComponent /></VisualizationProvider>
+        );
+
+        act(() => {
+            getByTestId('setVisualization').click();
+        });
+
+        // Only visualization changed, others remain null
+        expect(getByTestId('visualization')).toHaveTextContent('LineChart');
+        expect(getByTestId('settings')).toHaveTextContent('null');
+        expect(getByTestId('selectables')).toHaveTextContent('null');
+
+        act(() => {
+            getByTestId('setSettings').click();
+        });
+
+        // Visualization still set, settings updated, selectables still null
+        expect(getByTestId('visualization')).toHaveTextContent('LineChart');
+        expect(getByTestId('settings')).toHaveTextContent('"cutYAxis":true');
+        expect(getByTestId('selectables')).toHaveTextContent('null');
+    });
+});

--- a/PxGraf.Frontend/src/contexts/editorContext.tsx
+++ b/PxGraf.Frontend/src/contexts/editorContext.tsx
@@ -1,129 +1,23 @@
 /* istanbul ignore file */
 
-import { debounce } from 'lodash';
 import * as React from 'react';
-import { ICubeQuery, Query } from 'types/query';
-import { IVisualizationSettings } from 'types/visualizationSettings';
-import { VisualizationType } from 'types/visualizationType';
+import { QueryProvider } from './queryContext';
+import { VisualizationProvider } from './visualizationContext';
+import { SaveProvider } from './saveContext';
 
 /**
- * Interface for editor context properties
- * @property {ICubeQuery} cubeQuery - Query object that contains the header and dimension queries
- * @property {React.Dispatch<ICubeQuery>} setCubeQuery - Function to set the cube query
- * @property {Query} query - Query object that contains the dimension queries
- * @property {React.Dispatch<Query>} setQuery - Function to set the query
- * @property {boolean} saveDialogOpen - Flag to indicate if the save dialog is open
- * @property {React.Dispatch<boolean>} setSaveDialogOpen - Function to set the save dialog open flag
- * @property {VisualizationType} selectedVisualizationUserInput - The selected visualization type
- * @property {React.Dispatch<VisualizationType>} setSelectedVisualizationUserInput - Function to set the selected visualization type
- * @property {IVisualizationSettings} visualizationSettingsUserInput - The visualization settings
- * @property {React.Dispatch<IVisualizationSettings>} setVisualizationSettingsUserInput - Function to set the visualization settings
- * @property {{ [key: string]: string[] }} defaultSelectables - The default selectables for each dimension
- * @property {React.Dispatch<{ [key: string]: string[] }>} setDefaultSelectables - Function to set the default selectables
- * @property {string} loadedQueryId - The id of the loaded query if any
- * @property {React.Dispatch<string>} setLoadedQueryId - Function to set the query id when loading a query
- * @property {boolean} loadedQueryIsDraft - Flag to indicate if the loaded query is a draft
- * @property {React.Dispatch<boolean>} setLoadedQueryIsDraft - Function to set the loaded query draft state
- * @property {boolean} publicationWebhookEnabled - Flag to indicate if publication webhooks are enabled
- * @property {React.Dispatch<boolean>} setPublicationWebhookEnabled - Function to set the publication enabled state
+ * Composite provider that wraps all editor sub-contexts.
+ * Components should consume the specific context they need:
+ * - QueryContext for cubeQuery / query
+ * - VisualizationContext for visualization type / settings / defaultSelectables
+ * - SaveContext for save dialog / loaded query / publication state
  */
-interface IEditorContext {
-    cubeQuery: ICubeQuery;
-    setCubeQuery: React.Dispatch<ICubeQuery>;
-    query: Query;
-    setQuery: React.Dispatch<Query>;
-    saveDialogOpen: boolean;
-    setSaveDialogOpen: React.Dispatch<boolean>;
-    selectedVisualizationUserInput: VisualizationType;
-    setSelectedVisualizationUserInput: React.Dispatch<VisualizationType>;
-    visualizationSettingsUserInput: IVisualizationSettings;
-    setVisualizationSettingsUserInput: React.Dispatch<IVisualizationSettings>;
-    defaultSelectables: { [key: string]: string[] };
-    setDefaultSelectables: React.Dispatch<{ [key: string]: string[] }>;
-    loadedQueryId: string;
-    setLoadedQueryId: React.Dispatch<string>;
-    loadedQueryIsDraft: boolean;
-    setLoadedQueryIsDraft: React.Dispatch<boolean>;
-    publicationWebhookEnabled: boolean;
-    setPublicationWebhookEnabled: React.Dispatch<boolean>;
-}
-
-/**
- * Context required for the editor
- */
-export const EditorContext = React.createContext<IEditorContext>({
-    cubeQuery: null,
-    setCubeQuery: () => { /* no base implementation */ },
-    query: null,
-    setQuery: () => { /* no base implementation */ },
-    saveDialogOpen: false,
-    setSaveDialogOpen: () => { /* no base implementation */ },
-    selectedVisualizationUserInput: null,
-    setSelectedVisualizationUserInput: () => { /* no base implementation */ },
-    visualizationSettingsUserInput: null,
-    setVisualizationSettingsUserInput: () => { /* no base implementation */ },
-    defaultSelectables: null,
-    setDefaultSelectables: () => { /* no base implementation */ },
-    loadedQueryId: '',
-    setLoadedQueryId: () => { /* no base implementation */ },
-    loadedQueryIsDraft: false,
-    setLoadedQueryIsDraft: () => { /* no base implementation */ },
-    publicationWebhookEnabled: true,
-    setPublicationWebhookEnabled: () => { /* no base implementation */ },
-});
-
-/**
- * Provider for the editor context
- * @param children - The child components
- */
-export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-    const [cubeQuery, setCubeQueryState] = React.useState({ variableQueries: {} });
-    const [query, setQuery] = React.useState(null);
-    const [saveDialogOpen, setSaveDialogOpen] = React.useState(false);
-    const [selectedVisualizationUserInput, setSelectedVisualizationUserInput] = React.useState(null);
-    const [visualizationSettingsUserInput, setVisualizationSettingsUserInput] = React.useState(null);
-    const [defaultSelectables, setDefaultSelectables] = React.useState(null);
-    const [loadedQueryId, setLoadedQueryId] = React.useState('');
-    const [loadedQueryIsDraft, setLoadedQueryIsDraft] = React.useState(false);
-    const [publicationWebhookEnabled, setPublicationWebhookEnabled] = React.useState(true);
-
-    const debouncedCubeQuery = React.useMemo(() => {
-        return debounce((newQuery: ICubeQuery) => {
-            setCubeQueryState(newQuery);
-        }, 1000);
-    }, []);
-
-    const setCubeQuery = React.useCallback((newQuery: ICubeQuery) => {
-        debouncedCubeQuery(newQuery);
-    }, [debouncedCubeQuery]);
-
-    React.useEffect(() => {
-        return () => {
-            debouncedCubeQuery.cancel();
-        };
-    }, [debouncedCubeQuery]);
-
-    const contextValue = React.useMemo(() => {
-        return {
-            cubeQuery, setCubeQuery,
-            query, setQuery,
-            saveDialogOpen, setSaveDialogOpen,
-            selectedVisualizationUserInput, setSelectedVisualizationUserInput,
-            visualizationSettingsUserInput, setVisualizationSettingsUserInput,
-            defaultSelectables, setDefaultSelectables,
-            loadedQueryId, setLoadedQueryId,
-            loadedQueryIsDraft, setLoadedQueryIsDraft,
-            publicationWebhookEnabled, setPublicationWebhookEnabled,
-        }
-    }, [
-        cubeQuery, query, saveDialogOpen, selectedVisualizationUserInput,
-        visualizationSettingsUserInput, defaultSelectables, loadedQueryId,
-        loadedQueryIsDraft, publicationWebhookEnabled
-    ]);
-
-    return (
-        <EditorContext.Provider value={contextValue}>
-            {children}
-        </EditorContext.Provider>
-    );
-}
+export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <QueryProvider>
+        <VisualizationProvider>
+            <SaveProvider>
+                {children}
+            </SaveProvider>
+        </VisualizationProvider>
+    </QueryProvider>
+);

--- a/PxGraf.Frontend/src/contexts/queryContext.tsx
+++ b/PxGraf.Frontend/src/contexts/queryContext.tsx
@@ -1,5 +1,3 @@
-/* istanbul ignore file */
-
 import { debounce } from 'lodash';
 import * as React from 'react';
 import { ICubeQuery, Query } from 'types/query';

--- a/PxGraf.Frontend/src/contexts/queryContext.tsx
+++ b/PxGraf.Frontend/src/contexts/queryContext.tsx
@@ -4,6 +4,7 @@ import { ICubeQuery, Query } from 'types/query';
 
 interface IQueryContext {
     cubeQuery: ICubeQuery;
+    /** Debounced setter (1 s) — accepts a full ICubeQuery value, not a functional updater. */
     setCubeQuery: (newQuery: ICubeQuery) => void;
     query: Query | null;
     setQuery: React.Dispatch<React.SetStateAction<Query | null>>;

--- a/PxGraf.Frontend/src/contexts/queryContext.tsx
+++ b/PxGraf.Frontend/src/contexts/queryContext.tsx
@@ -1,0 +1,51 @@
+/* istanbul ignore file */
+
+import { debounce } from 'lodash';
+import * as React from 'react';
+import { ICubeQuery, Query } from 'types/query';
+
+interface IQueryContext {
+    cubeQuery: ICubeQuery;
+    setCubeQuery: (newQuery: ICubeQuery) => void;
+    query: Query;
+    setQuery: React.Dispatch<React.SetStateAction<Query>>;
+}
+
+export const QueryContext = React.createContext<IQueryContext>({
+    cubeQuery: null,
+    setCubeQuery: () => { /* no base implementation */ },
+    query: null,
+    setQuery: () => { /* no base implementation */ },
+});
+
+export const QueryProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [cubeQuery, setCubeQueryState] = React.useState({ variableQueries: {} });
+    const [query, setQuery] = React.useState(null);
+
+    const debouncedCubeQuery = React.useMemo(() => {
+        return debounce((newQuery: ICubeQuery) => {
+            setCubeQueryState(newQuery);
+        }, 1000);
+    }, []);
+
+    const setCubeQuery = React.useCallback((newQuery: ICubeQuery) => {
+        debouncedCubeQuery(newQuery);
+    }, [debouncedCubeQuery]);
+
+    React.useEffect(() => {
+        return () => {
+            debouncedCubeQuery.cancel();
+        };
+    }, [debouncedCubeQuery]);
+
+    const contextValue = React.useMemo(() => ({
+        cubeQuery, setCubeQuery,
+        query, setQuery,
+    }), [cubeQuery, setCubeQuery, query, setQuery]);
+
+    return (
+        <QueryContext.Provider value={contextValue}>
+            {children}
+        </QueryContext.Provider>
+    );
+};

--- a/PxGraf.Frontend/src/contexts/queryContext.tsx
+++ b/PxGraf.Frontend/src/contexts/queryContext.tsx
@@ -5,20 +5,20 @@ import { ICubeQuery, Query } from 'types/query';
 interface IQueryContext {
     cubeQuery: ICubeQuery;
     setCubeQuery: (newQuery: ICubeQuery) => void;
-    query: Query;
-    setQuery: React.Dispatch<React.SetStateAction<Query>>;
+    query: Query | null;
+    setQuery: React.Dispatch<React.SetStateAction<Query | null>>;
 }
 
 export const QueryContext = React.createContext<IQueryContext>({
-    cubeQuery: null,
+    cubeQuery: { variableQueries: {} },
     setCubeQuery: () => { /* no base implementation */ },
     query: null,
     setQuery: () => { /* no base implementation */ },
 });
 
 export const QueryProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-    const [cubeQuery, setCubeQueryState] = React.useState({ variableQueries: {} });
-    const [query, setQuery] = React.useState(null);
+    const [cubeQuery, setCubeQueryState] = React.useState<ICubeQuery>({ variableQueries: {} });
+    const [query, setQuery] = React.useState<Query | null>(null);
 
     const debouncedCubeQuery = React.useMemo(() => {
         return debounce((newQuery: ICubeQuery) => {

--- a/PxGraf.Frontend/src/contexts/saveContext.tsx
+++ b/PxGraf.Frontend/src/contexts/saveContext.tsx
@@ -1,5 +1,3 @@
-/* istanbul ignore file */
-
 import * as React from 'react';
 
 interface ISaveContext {

--- a/PxGraf.Frontend/src/contexts/saveContext.tsx
+++ b/PxGraf.Frontend/src/contexts/saveContext.tsx
@@ -1,0 +1,45 @@
+/* istanbul ignore file */
+
+import * as React from 'react';
+
+interface ISaveContext {
+    saveDialogOpen: boolean;
+    setSaveDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    loadedQueryId: string;
+    setLoadedQueryId: React.Dispatch<React.SetStateAction<string>>;
+    loadedQueryIsDraft: boolean;
+    setLoadedQueryIsDraft: React.Dispatch<React.SetStateAction<boolean>>;
+    publicationWebhookEnabled: boolean;
+    setPublicationWebhookEnabled: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const SaveContext = React.createContext<ISaveContext>({
+    saveDialogOpen: false,
+    setSaveDialogOpen: () => { /* no base implementation */ },
+    loadedQueryId: '',
+    setLoadedQueryId: () => { /* no base implementation */ },
+    loadedQueryIsDraft: false,
+    setLoadedQueryIsDraft: () => { /* no base implementation */ },
+    publicationWebhookEnabled: true,
+    setPublicationWebhookEnabled: () => { /* no base implementation */ },
+});
+
+export const SaveProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [saveDialogOpen, setSaveDialogOpen] = React.useState(false);
+    const [loadedQueryId, setLoadedQueryId] = React.useState('');
+    const [loadedQueryIsDraft, setLoadedQueryIsDraft] = React.useState(false);
+    const [publicationWebhookEnabled, setPublicationWebhookEnabled] = React.useState(true);
+
+    const contextValue = React.useMemo(() => ({
+        saveDialogOpen, setSaveDialogOpen,
+        loadedQueryId, setLoadedQueryId,
+        loadedQueryIsDraft, setLoadedQueryIsDraft,
+        publicationWebhookEnabled, setPublicationWebhookEnabled,
+    }), [saveDialogOpen, setSaveDialogOpen, loadedQueryId, setLoadedQueryId, loadedQueryIsDraft, setLoadedQueryIsDraft, publicationWebhookEnabled, setPublicationWebhookEnabled]);
+
+    return (
+        <SaveContext.Provider value={contextValue}>
+            {children}
+        </SaveContext.Provider>
+    );
+};

--- a/PxGraf.Frontend/src/contexts/visualizationContext.tsx
+++ b/PxGraf.Frontend/src/contexts/visualizationContext.tsx
@@ -3,12 +3,12 @@ import { IVisualizationSettings } from 'types/visualizationSettings';
 import { VisualizationType } from 'types/visualizationType';
 
 interface IVisualizationContext {
-    selectedVisualizationUserInput: VisualizationType;
-    setSelectedVisualizationUserInput: React.Dispatch<React.SetStateAction<VisualizationType>>;
-    visualizationSettingsUserInput: IVisualizationSettings;
-    setVisualizationSettingsUserInput: React.Dispatch<React.SetStateAction<IVisualizationSettings>>;
-    defaultSelectables: { [key: string]: string[] };
-    setDefaultSelectables: React.Dispatch<React.SetStateAction<{ [key: string]: string[] }>>;
+    selectedVisualizationUserInput: VisualizationType | null;
+    setSelectedVisualizationUserInput: React.Dispatch<React.SetStateAction<VisualizationType | null>>;
+    visualizationSettingsUserInput: IVisualizationSettings | null;
+    setVisualizationSettingsUserInput: React.Dispatch<React.SetStateAction<IVisualizationSettings | null>>;
+    defaultSelectables: { [key: string]: string[] } | null;
+    setDefaultSelectables: React.Dispatch<React.SetStateAction<{ [key: string]: string[] } | null>>;
 }
 
 export const VisualizationContext = React.createContext<IVisualizationContext>({
@@ -21,9 +21,9 @@ export const VisualizationContext = React.createContext<IVisualizationContext>({
 });
 
 export const VisualizationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-    const [selectedVisualizationUserInput, setSelectedVisualizationUserInput] = React.useState(null);
-    const [visualizationSettingsUserInput, setVisualizationSettingsUserInput] = React.useState(null);
-    const [defaultSelectables, setDefaultSelectables] = React.useState(null);
+    const [selectedVisualizationUserInput, setSelectedVisualizationUserInput] = React.useState<VisualizationType | null>(null);
+    const [visualizationSettingsUserInput, setVisualizationSettingsUserInput] = React.useState<IVisualizationSettings | null>(null);
+    const [defaultSelectables, setDefaultSelectables] = React.useState<{ [key: string]: string[] } | null>(null);
 
     const contextValue = React.useMemo(() => ({
         selectedVisualizationUserInput, setSelectedVisualizationUserInput,

--- a/PxGraf.Frontend/src/contexts/visualizationContext.tsx
+++ b/PxGraf.Frontend/src/contexts/visualizationContext.tsx
@@ -1,5 +1,3 @@
-/* istanbul ignore file */
-
 import * as React from 'react';
 import { IVisualizationSettings } from 'types/visualizationSettings';
 import { VisualizationType } from 'types/visualizationType';

--- a/PxGraf.Frontend/src/contexts/visualizationContext.tsx
+++ b/PxGraf.Frontend/src/contexts/visualizationContext.tsx
@@ -1,0 +1,41 @@
+/* istanbul ignore file */
+
+import * as React from 'react';
+import { IVisualizationSettings } from 'types/visualizationSettings';
+import { VisualizationType } from 'types/visualizationType';
+
+interface IVisualizationContext {
+    selectedVisualizationUserInput: VisualizationType;
+    setSelectedVisualizationUserInput: React.Dispatch<React.SetStateAction<VisualizationType>>;
+    visualizationSettingsUserInput: IVisualizationSettings;
+    setVisualizationSettingsUserInput: React.Dispatch<React.SetStateAction<IVisualizationSettings>>;
+    defaultSelectables: { [key: string]: string[] };
+    setDefaultSelectables: React.Dispatch<React.SetStateAction<{ [key: string]: string[] }>>;
+}
+
+export const VisualizationContext = React.createContext<IVisualizationContext>({
+    selectedVisualizationUserInput: null,
+    setSelectedVisualizationUserInput: () => { /* no base implementation */ },
+    visualizationSettingsUserInput: null,
+    setVisualizationSettingsUserInput: () => { /* no base implementation */ },
+    defaultSelectables: null,
+    setDefaultSelectables: () => { /* no base implementation */ },
+});
+
+export const VisualizationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [selectedVisualizationUserInput, setSelectedVisualizationUserInput] = React.useState(null);
+    const [visualizationSettingsUserInput, setVisualizationSettingsUserInput] = React.useState(null);
+    const [defaultSelectables, setDefaultSelectables] = React.useState(null);
+
+    const contextValue = React.useMemo(() => ({
+        selectedVisualizationUserInput, setSelectedVisualizationUserInput,
+        visualizationSettingsUserInput, setVisualizationSettingsUserInput,
+        defaultSelectables, setDefaultSelectables,
+    }), [selectedVisualizationUserInput, setSelectedVisualizationUserInput, visualizationSettingsUserInput, setVisualizationSettingsUserInput, defaultSelectables, setDefaultSelectables]);
+
+    return (
+        <VisualizationContext.Provider value={contextValue}>
+            {children}
+        </VisualizationContext.Provider>
+    );
+};

--- a/PxGraf.Frontend/src/views/Editor/Editor.test.tsx
+++ b/PxGraf.Frontend/src/views/Editor/Editor.test.tsx
@@ -18,7 +18,9 @@ import '@testing-library/jest-dom';
 import { IVisualizationOptions } from '../../types/editorContentsResponse';
 import { VisualizationType } from '../../types/visualizationType';
 import { IEditorContentsResult } from '../../api/services/editor-contents';
-import { EditorContext } from '../../contexts/editorContext';
+import { QueryContext } from '../../contexts/queryContext';
+import { VisualizationContext } from '../../contexts/visualizationContext';
+import { SaveContext } from '../../contexts/saveContext';
 
 const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -422,34 +424,44 @@ describe('Assertion tests', () => {
         const setLoadedQueryId = jest.fn();
         const setLoadedQueryIsDraft = jest.fn();
 
-        const mockEditorContext = {
+        const mockQueryContext = {
             cubeQuery: { variableQueries: {} },
             setCubeQuery: jest.fn(),
             query: null,
             setQuery: jest.fn(),
-            saveDialogOpen: false,
-            setSaveDialogOpen: jest.fn(),
+        };
+
+        const mockVisualizationContext = {
             selectedVisualizationUserInput: null,
             setSelectedVisualizationUserInput,
             visualizationSettingsUserInput: null,
             setVisualizationSettingsUserInput: jest.fn(),
             defaultSelectables: null,
             setDefaultSelectables: jest.fn(),
+        };
+
+        const mockSaveContext = {
+            saveDialogOpen: false,
+            setSaveDialogOpen: jest.fn(),
             loadedQueryId: '',
             setLoadedQueryId,
             loadedQueryIsDraft: false,
             setLoadedQueryIsDraft,
             publicationWebhookEnabled: true,
-            setPublicationWebhookEnabled: jest.fn()
+            setPublicationWebhookEnabled: jest.fn(),
         };
 
         render(
             <QueryClientProvider client={queryClient}>
                 <NavigationProvider>
                     <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                        <EditorContext.Provider value={mockEditorContext}>
-                            <Editor />
-                        </EditorContext.Provider>
+                        <QueryContext.Provider value={mockQueryContext}>
+                            <VisualizationContext.Provider value={mockVisualizationContext}>
+                                <SaveContext.Provider value={mockSaveContext}>
+                                    <Editor />
+                                </SaveContext.Provider>
+                            </VisualizationContext.Provider>
+                        </QueryContext.Provider>
                     </UiLanguageContext.Provider>
                 </NavigationProvider>
             </QueryClientProvider>
@@ -463,34 +475,44 @@ describe('Assertion tests', () => {
     it('calls setPublicationWebhookEnabled when editorContentsResponse has publicationWebhookEnabled property', () => {
         const setPublicationWebhookEnabled = jest.fn();
 
-        const mockEditorContextWithPublication = {
+        const mockQueryContext = {
             cubeQuery: { variableQueries: {} },
             setCubeQuery: jest.fn(),
             query: null,
             setQuery: jest.fn(),
-            saveDialogOpen: false,
-            setSaveDialogOpen: jest.fn(),
+        };
+
+        const mockVisualizationContext = {
             selectedVisualizationUserInput: null,
             setSelectedVisualizationUserInput: jest.fn(),
             visualizationSettingsUserInput: null,
             setVisualizationSettingsUserInput: jest.fn(),
             defaultSelectables: null,
             setDefaultSelectables: jest.fn(),
+        };
+
+        const mockSaveContext = {
+            saveDialogOpen: false,
+            setSaveDialogOpen: jest.fn(),
             loadedQueryId: '',
             setLoadedQueryId: jest.fn(),
             loadedQueryIsDraft: false,
             setLoadedQueryIsDraft: jest.fn(),
             publicationWebhookEnabled: true,
-            setPublicationWebhookEnabled
+            setPublicationWebhookEnabled,
         };
 
         render(
             <QueryClientProvider client={queryClient}>
                 <NavigationProvider>
                     <UiLanguageContext.Provider value={{ language, setLanguage, languageTab, setLanguageTab, availableUiLanguages, uiContentLanguage, setUiContentLanguage }}>
-                        <EditorContext.Provider value={mockEditorContextWithPublication}>
-                            <Editor />
-                        </EditorContext.Provider>
+                        <QueryContext.Provider value={mockQueryContext}>
+                            <VisualizationContext.Provider value={mockVisualizationContext}>
+                                <SaveContext.Provider value={mockSaveContext}>
+                                    <Editor />
+                                </SaveContext.Provider>
+                            </VisualizationContext.Provider>
+                        </QueryContext.Provider>
                     </UiLanguageContext.Provider>
                 </NavigationProvider>
             </QueryClientProvider>

--- a/PxGraf.Frontend/src/views/Editor/Editor.tsx
+++ b/PxGraf.Frontend/src/views/Editor/Editor.tsx
@@ -140,7 +140,7 @@ export const Editor = () => {
         if (query != null) {
             return query;
         }
-        else if (dimensions == null) {
+        else if (cubeMetaResponse.data == null) {
             return null;
         }
         else {
@@ -162,7 +162,7 @@ export const Editor = () => {
         if (resolvedDimensionCodesResponse.data != null) {
             return resolvedDimensionCodesResponse.data;
         }
-        else if (dimensions == null) {
+        else if (cubeMetaResponse.data == null) {
             return {};
         }
         else {

--- a/PxGraf.Frontend/src/views/Editor/Editor.tsx
+++ b/PxGraf.Frontend/src/views/Editor/Editor.tsx
@@ -2,7 +2,9 @@ import React, { useEffect } from 'react';
 import { useParams, useLocation } from "react-router-dom";
 import { useTranslation } from 'react-i18next';
 import { Box, Stack, Divider, Container, CircularProgress, Alert } from '@mui/material';
-import { EditorContext } from 'contexts/editorContext';
+import { QueryContext } from 'contexts/queryContext';
+import { VisualizationContext } from 'contexts/visualizationContext';
+import { SaveContext } from 'contexts/saveContext';
 import { getDefaultQueries, getVisualizationOptionsForVisualizationType, resolveDimensions } from 'utils/editorHelpers';
 import EditorFilterSection from './EditorFilterSection';
 import EditorFooterSection from './EditorFooterSection';
@@ -68,22 +70,19 @@ export const Editor = () => {
 
     // statemanagement
     const {
-        cubeQuery,
-        query,
-        selectedVisualizationUserInput,
-        visualizationSettingsUserInput,
-        setQuery,
-        setCubeQuery,
-        setVisualizationSettingsUserInput,
-        setSelectedVisualizationUserInput,
-        defaultSelectables,
-        setDefaultSelectables,
-        loadedQueryId,
-        setLoadedQueryId,
-        loadedQueryIsDraft,
-        setLoadedQueryIsDraft,
-        setPublicationWebhookEnabled
-    } = React.useContext(EditorContext);
+        cubeQuery, setCubeQuery,
+        query, setQuery,
+    } = React.useContext(QueryContext);
+    const {
+        selectedVisualizationUserInput, setSelectedVisualizationUserInput,
+        visualizationSettingsUserInput, setVisualizationSettingsUserInput,
+        defaultSelectables, setDefaultSelectables,
+    } = React.useContext(VisualizationContext);
+    const {
+        loadedQueryId, setLoadedQueryId,
+        loadedQueryIsDraft, setLoadedQueryIsDraft,
+        setPublicationWebhookEnabled,
+    } = React.useContext(SaveContext);
 
     const { setTablePath } = useNavigationContext();
 
@@ -141,11 +140,11 @@ export const Editor = () => {
         if (query != null) {
             return query;
         }
-        else if (dimensions != null) {
-            return getDefaultQueries(dimensions);
+        else if (dimensions == null) {
+            return null;
         }
         else {
-            return null;
+            return getDefaultQueries(dimensions);
         }
     }, [query, cubeMetaResponse.data]);
 
@@ -163,15 +162,15 @@ export const Editor = () => {
         if (resolvedDimensionCodesResponse.data != null) {
             return resolvedDimensionCodesResponse.data;
         }
-        else if (dimensions != null) {
+        else if (dimensions == null) {
+            return {};
+        }
+        else {
             const dimCodesNoVals = {}
             dimensions.forEach(v => {
                 dimCodesNoVals[v.code] = [];
             })
             return dimCodesNoVals;
-        }
-        else {
-            return {};
         }
     }, [resolvedDimensionCodesResponse, cubeMetaResponse.data]);
     const resolvedDimensions = React.useMemo(() => {

--- a/PxGraf.Frontend/src/views/Editor/EditorDialogs.tsx
+++ b/PxGraf.Frontend/src/views/Editor/EditorDialogs.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { UseMutationResult } from '@tanstack/react-query';
 import { SaveDialog } from 'components/SaveDialog/SaveDialog';
 import { SaveResultDialog } from 'components/SaveResultDialog/SaveResultDialog';
-import { EditorContext } from 'contexts/editorContext';
+import { SaveContext } from 'contexts/saveContext';
 import { ISaveQueryResponse, ISaveQueryMutationParams } from 'api/services/queries';
 
 interface IEditorDialogsProps {
@@ -10,7 +10,7 @@ interface IEditorDialogsProps {
 }
 
 export const EditorDialogs: React.FC<IEditorDialogsProps> = ({ saveQueryMutation }) => {
-    const { setSaveDialogOpen, setLoadedQueryId, setLoadedQueryIsDraft } = React.useContext(EditorContext);
+    const { setSaveDialogOpen, setLoadedQueryId, setLoadedQueryIsDraft } = React.useContext(SaveContext);
     const [saveResultDialogOpen, setSaveResultDialogOpen] = React.useState(false);
     const [lastSavedAsDraft, setLastSavedAsDraft] = React.useState(false);
 

--- a/PxGraf.Frontend/src/views/Editor/EditorFooterSection.tsx
+++ b/PxGraf.Frontend/src/views/Editor/EditorFooterSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, Button } from '@mui/material';
 import SaveIcon from '@mui/icons-material/Save';
-import { EditorContext } from 'contexts/editorContext';
+import { SaveContext } from 'contexts/saveContext';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import InfoBubble from 'components/InfoBubble/InfoBubble';
@@ -17,7 +17,7 @@ const FooterBtnWrapper = styled(Box)`
 
 export const EditorFooterSection: React.FC = () => {
     
-    const { setSaveDialogOpen } = React.useContext(EditorContext);
+    const { setSaveDialogOpen } = React.useContext(SaveContext);
     
     const { t } = useTranslation();
     


### PR DESCRIPTION
Split the single EditorContext (10 state values + 10 setters) into three
domain-specific contexts to reduce unnecessary re-renders:

- QueryContext: cubeQuery (debounced), query + setters
- VisualizationContext: chart type, settings, defaultSelectables + setters
- SaveContext: save dialog, loaded query ID/draft, webhook flag + setters

EditorProvider remains as a thin composite wrapper nesting all three
providers, so Router.tsx requires no changes.

Updated 16 consumer components and 13 test files to import the specific
context they need. Added unit tests for all three new contexts (15 tests).

Setter types corrected to React.Dispatch<React.SetStateAction<T>> and
useMemo dependency arrays completed with all setter references.