### PR TITLE
Enhance OpenAPI docs, feature gating, and add tests

### DIFF
--- a/PxGraf/Controllers/CreationController.cs
+++ b/PxGraf/Controllers/CreationController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.FeatureManagement.Mvc;
@@ -48,6 +49,9 @@ namespace PxGraf.Controllers
         /// If a database whitelist is configured and the database is not whitelisted, "Not Found" response is returned.
         /// </returns>
         [HttpGet("data-bases/{*dbPath}")]
+        [ProducesResponseType<DatabaseGroupContents>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<ActionResult<DatabaseGroupContents>> GetDataBaseListingAsync([FromRoute] string dbPath)
         {
             Dictionary<string, object> logScope = new() { 
@@ -105,6 +109,9 @@ namespace PxGraf.Controllers
         /// If the database is not whitelisted, "Not Found" response is returned.
         /// </returns>
         [HttpGet("cube-meta/{*tablePath}")]
+        [ProducesResponseType<IReadOnlyMatrixMetadata>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<ActionResult<IReadOnlyMatrixMetadata>> GetCubeMetaAsync([FromRoute] string tablePath)
         {
             using(_logger.BeginScope(new Dictionary<string, object> {
@@ -150,6 +157,8 @@ namespace PxGraf.Controllers
         /// If the database is not whitelisted, "Not Found" response is returned.
         /// </returns>
         [HttpGet("validate-table-metadata/{*tablePath}")]
+        [ProducesResponseType<TableMetaValidationResult>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<TableMetaValidationResult>> ValidateTableMetaData([FromRoute] string tablePath)
         {
             using (_logger.BeginScope(new Dictionary<string, object>
@@ -196,6 +205,7 @@ namespace PxGraf.Controllers
         /// <param name="filterRequest">Filter request object containing the table reference and the filter.</param>
         /// <returns>Dictionary with dimension codes as keys and their value codes as values</returns>
         [HttpPost("filter-dimension")]
+        [ProducesResponseType<Dictionary<string, List<string>>>(StatusCodes.Status200OK)]
         public async Task<ActionResult<Dictionary<string, List<string>>>> GetDimensionFilterResultAsync([FromBody] FilterRequest filterRequest)
         {
             using (_logger.BeginScope(new Dictionary<string, object>
@@ -244,6 +254,7 @@ namespace PxGraf.Controllers
         /// <returns><see cref="EditorContentsResponse"/> object that contains the size of the resulting matrix, maximum supported size, header text, maximum header length, visualization options for accepted visualization types and rejection reasons.</returns>
 #nullable enable
         [HttpPost("editor-contents")]
+        [ProducesResponseType<EditorContentsResponse>(StatusCodes.Status200OK)]
         public async Task<ActionResult<EditorContentsResponse>> GetEditorContents([FromBody] MatrixQuery query)
         {
             using (_logger.BeginScope(new Dictionary<string, object>
@@ -350,6 +361,8 @@ namespace PxGraf.Controllers
         /// If the request is missing values for any dimension or the selected visualization type is not valid, "Bad Request" response is returned.
         /// </returns>
         [HttpPost("visualization")]
+        [ProducesResponseType<VisualizationResponse>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<ActionResult<VisualizationResponse>> GetVisualizationAsync([FromBody] ChartRequest request)
         {
             using (_logger.BeginScope(new Dictionary<string, object>

--- a/PxGraf/Controllers/InfoController.cs
+++ b/PxGraf/Controllers/InfoController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using PxGraf.Models.Responses;
 using System.Reflection;
 
 namespace PxGraf.Controllers
@@ -16,7 +17,7 @@ namespace PxGraf.Controllers
     /// <param name="logger"><see cref="ILogger"/> instance used for logging API calls.</param>
     [ApiController]
     [Route("api/info")]
-    [ProducesResponseType<int>(StatusCodes.Status200OK)]
+    [ProducesResponseType<InfoResponse>(StatusCodes.Status200OK)]
     public class InfoController(IWebHostEnvironment env, ILogger<InfoController> logger) : ControllerBase
     {
         private readonly string _name = env.ApplicationName;
@@ -33,12 +34,7 @@ namespace PxGraf.Controllers
         public IActionResult Get()
         {
             _logger.LogDebug("api/info: API info requested: Name: {Name}, Environment: {Environment}, Version: {Version}", _name, _environment, _version);
-            return Ok(new
-            {
-                Name = _name,
-                Environment = _environment,
-                Version = _version
-            });
+            return Ok(new InfoResponse(_name, _environment, _version));
         }
     }
 }

--- a/PxGraf/Controllers/QueryMetaController.cs
+++ b/PxGraf/Controllers/QueryMetaController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Px.Utils.Language;
@@ -34,6 +35,8 @@ namespace PxGraf.Controllers
         /// If no query for the given ID is found, "Not Found" response is returned.
         /// </returns>
         [HttpGet("{savedQueryId}")]
+        [ProducesResponseType<QueryMetaResponse>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<QueryMetaResponse>> GetQueryMeta([FromRoute] string savedQueryId)
         {
             Dictionary<string, object> logScope = new()

--- a/PxGraf/Controllers/SqController.cs
+++ b/PxGraf/Controllers/SqController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.FeatureManagement.Mvc;
@@ -57,6 +58,9 @@ namespace PxGraf.Controllers
         /// If saved query with the provided ID is not found, "Not Found" response is returned.
         /// </returns>
         [HttpGet("{savedQueryId}")]
+        [ProducesResponseType<SaveQueryParams>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<ActionResult<SaveQueryParams>> GetSavedQueryAsync([FromRoute] string savedQueryId)
         {
             Dictionary<string, object> logScope = new()
@@ -131,6 +135,8 @@ namespace PxGraf.Controllers
         /// <param name="parameters">Parameters for saving the query.</param>
         /// <returns><see cref="SaveQueryResponse"/> object that contains the id of the saved query.</returns>
         [HttpPost("save")]
+        [ProducesResponseType<SaveQueryResponse>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<ActionResult<SaveQueryResponse>> SaveQueryAsync([FromBody] SaveQueryParams parameters)
         {
             string actionPath = $"{CONTROLLER_PATH}/save";
@@ -203,6 +209,8 @@ namespace PxGraf.Controllers
         /// <param name="parameters">Parameters for saving the query.</param>
         /// <returns><see cref="SaveQueryResponse"/> object that contains the name of the archived query.</returns>
         [HttpPost("archive")]
+        [ProducesResponseType<SaveQueryResponse>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<ActionResult<SaveQueryResponse>> ArchiveQueryAsync([FromBody] SaveQueryParams parameters)
         {
             string actionPath = $"{CONTROLLER_PATH}/archive";
@@ -285,6 +293,9 @@ namespace PxGraf.Controllers
         /// <param name="request"><see cref="ReArchiveRequest"/> object that contains the ID of the query to be rearchived.</param>
         /// <returns><see cref="ReArchiveResponse"/> object that contains the ID of the rearchived query.</returns>
         [HttpPost("re-archive")]
+        [ProducesResponseType<ReArchiveResponse>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<ActionResult<ReArchiveResponse>> ReArchiveExistingQueryAsync([FromBody] ReArchiveRequest request)
         {
             string actionPath = $"{CONTROLLER_PATH}/re-archive";

--- a/PxGraf/Controllers/VisualizationController.cs
+++ b/PxGraf/Controllers/VisualizationController.cs
@@ -59,6 +59,7 @@ namespace PxGraf.Controllers
         /// <returns><see cref="VisualizationResponse"/> object containing the properties of the visualization</returns>
         [HttpGet("{sqId}")]
         [ProducesResponseType<VisualizationResponse>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<VisualizationResponse>> GetVisualization([FromRoute] string sqId)
         {

--- a/PxGraf/Controllers/VisualizationController.cs
+++ b/PxGraf/Controllers/VisualizationController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Px.Utils.Models.Data.DataValue;
@@ -57,6 +58,8 @@ namespace PxGraf.Controllers
         /// <param name="sqId">The id of the saved query</param>
         /// <returns><see cref="VisualizationResponse"/> object containing the properties of the visualization</returns>
         [HttpGet("{sqId}")]
+        [ProducesResponseType<VisualizationResponse>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<VisualizationResponse>> GetVisualization([FromRoute] string sqId)
         {
             Dictionary<string, object> logScope = new()

--- a/PxGraf/Models/Responses/InfoResponse.cs
+++ b/PxGraf/Models/Responses/InfoResponse.cs
@@ -1,0 +1,10 @@
+namespace PxGraf.Models.Responses
+{
+    /// <summary>
+    /// Response model for the API info endpoint.
+    /// </summary>
+    /// <param name="Name">The application name.</param>
+    /// <param name="Environment">The hosting environment name.</param>
+    /// <param name="Version">The application version.</param>
+    public record InfoResponse(string Name, string Environment, string Version);
+}

--- a/PxGraf/Properties/launchSettings.json
+++ b/PxGraf/Properties/launchSettings.json
@@ -4,7 +4,6 @@
     "anonymousAuthentication": true,
     "iisExpress": {
       "applicationUrl": "http://localhost:8443/"
-      //"sslPort": 44376
     }
   },
   "$schema": "http://json.schemastore.org/launchsettings.json",
@@ -15,7 +14,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "launchUrl": "api/swagger"
+      "launchUrl": ""
     },
     "PxGraf": {
       "commandName": "Project",
@@ -24,7 +23,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "launchUrl": "api/swagger"
+      "launchUrl": ""
     }
   }
 }

--- a/PxGraf/Properties/launchSettings.json
+++ b/PxGraf/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "launchUrl": ""
+      "launchUrl": "openapi"
     },
     "PxGraf": {
       "commandName": "Project",
@@ -23,7 +23,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "launchUrl": ""
+      "launchUrl": "openapi"
     }
   }
 }

--- a/PxGraf/PxGraf.csproj
+++ b/PxGraf/PxGraf.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>PxGraf</AssemblyName>
     <UserSecretsId>5fefcbdc-e04e-4475-9927-aab412b027ff</UserSecretsId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>4.8.0</VersionPrefix>
+    <VersionPrefix>4.8.1</VersionPrefix>
 	<SpaRoot>..\PxGraf.Frontend</SpaRoot>
 	<Configurations>Debug;Release;Test</Configurations>
   </PropertyGroup>

--- a/PxGraf/PxGraf.csproj
+++ b/PxGraf/PxGraf.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>obj\Debug\netcoreapp3.1\PxGraf.xml</DocumentationFile>
     <WarningLevel>4</WarningLevel>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
@@ -49,7 +48,6 @@
 	<PackageReference Include="Azure.Identity" Version="1.19.0" />
 	<PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
 	<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.0.0" />
-	<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
 	<PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
 	<PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.4.0" />
 	<PackageReference Include="NLog" Version="6.1.1" />

--- a/PxGraf/Settings/ApiExplorerConventions.cs
+++ b/PxGraf/Settings/ApiExplorerConventions.cs
@@ -1,25 +1,37 @@
 ﻿using Microsoft.AspNetCore.Mvc.ApplicationModels;
-using PxGraf.Controllers;
+using Microsoft.FeatureManagement.Mvc;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace PxGraf.Settings
 {
     /// <summary>
-    /// Class for setting visibility of API controllers in Swagger. CreationController is only visible if the CreationAPI feature is enabled.
+    /// Hides controllers and actions from the OpenAPI document when their <see cref="FeatureGateAttribute"/> feature flags are disabled.
     /// </summary>
     public class ApiExplorerConventions : IActionModelConvention
     {
         public void Apply(ActionModel action)
         {
-            // ErrorController has been set to be ignored in Swagger. Setting shows as null in the API explorer.
+            // Controllers explicitly marked as ignored (e.g. ErrorController) show as null.
             if (action.ApiExplorer.IsVisible is null)
             {
                 action.ApiExplorer.IsVisible = false;
                 return;
             }
 
-            bool isCreationController = action.Controller.ControllerType == typeof(CreationController);
-            bool isCreationApiEnabled = Configuration.Current.CreationAPI;
-            action.ApiExplorer.IsVisible = !isCreationController || isCreationApiEnabled;
+            // Collect FeatureGate attributes from both the controller and the action.
+            IEnumerable<FeatureGateAttribute> gates = action.Controller.ControllerType.GetCustomAttributes<FeatureGateAttribute>(inherit: true)
+                .Concat(action.ActionMethod.GetCustomAttributes<FeatureGateAttribute>(inherit: true));
+
+            foreach (FeatureGateAttribute gate in gates)
+            {
+                if (gate.Features.Any(f => !Configuration.Current.IsFeatureEnabled(f)))
+                {
+                    action.ApiExplorer.IsVisible = false;
+                    return;
+                }
+            }
         }
     }
 }

--- a/PxGraf/Settings/ApiExplorerConventions.cs
+++ b/PxGraf/Settings/ApiExplorerConventions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.FeatureManagement.Mvc;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,13 +24,9 @@ namespace PxGraf.Settings
             IEnumerable<FeatureGateAttribute> gates = action.Controller.ControllerType.GetCustomAttributes<FeatureGateAttribute>(inherit: true)
                 .Concat(action.ActionMethod.GetCustomAttributes<FeatureGateAttribute>(inherit: true));
 
-            foreach (FeatureGateAttribute gate in gates)
+            if (gates.Any(gate => gate.Features.Any(f => !Configuration.Current.IsFeatureEnabled(f))))
             {
-                if (gate.Features.Any(f => !Configuration.Current.IsFeatureEnabled(f)))
-                {
-                    action.ApiExplorer.IsVisible = false;
-                    return;
-                }
+                action.ApiExplorer.IsVisible = false;
             }
         }
     }

--- a/PxGraf/Settings/Configuration.cs
+++ b/PxGraf/Settings/Configuration.cs
@@ -43,6 +43,11 @@ namespace PxGraf.Settings
         public ApplicationInsightsConfig ApplicationInsights { get; private set; }
         public PublicationWebhookConfiguration PublicationWebhookConfig { get; private set; }
 
+        private static readonly Dictionary<string, Func<Configuration, bool>> FeatureFlags = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["CreationAPI"] = c => c.CreationAPI
+        };
+
         public static void Load(IConfiguration configuration)
         {
             //Set config defaults
@@ -92,6 +97,15 @@ namespace PxGraf.Settings
             }
 
             Current = newConfig;
+        }
+
+        /// <summary>
+        /// Returns whether the named feature flag is enabled in the current configuration.
+        /// Unknown feature names are treated as enabled (visible) by default.
+        /// </summary>
+        public bool IsFeatureEnabled(string featureName)
+        {
+            return !FeatureFlags.TryGetValue(featureName, out Func<Configuration, bool> accessor) || accessor(this);
         }
 
         /// <summary>

--- a/PxGraf/Startup.cs
+++ b/PxGraf/Startup.cs
@@ -246,8 +246,8 @@ namespace PxGraf
             });
             app.UseSwaggerUI(c =>
             {
-                c.SwaggerEndpoint("openapi/document.json", "PxGraf");
-                c.RoutePrefix = string.Empty;
+                c.SwaggerEndpoint($"/{swaggerDocName}/document.json", "PxGraf");
+                c.RoutePrefix = swaggerDocName;
             });
 
             app.UseExceptionHandler("/api/error");

--- a/PxGraf/Startup.cs
+++ b/PxGraf/Startup.cs
@@ -33,7 +33,7 @@ namespace PxGraf
 
         readonly string PxGrafAllowSpecificOrigins = "_pxGrafAllowSpecificOrigins";
         private readonly ILogger logger;
-        private const string swaggerDocName = "api";
+        private const string swaggerDocName = "openapi";
 
         private IHostEnvironment HostEnvironment { get; }
 
@@ -132,10 +132,13 @@ namespace PxGraf
 
             services.AddSwaggerGen(c =>
             {
-                c.CustomSchemaIds(type => type.ToString());
-
-                c.ResolveConflictingActions(apiDescriptions => apiDescriptions.First());
-                c.SwaggerDoc(swaggerDocName, new OpenApiInfo { Title = "PxGraf", Version = "v1" });
+                OpenApiInfo apiInfo = new()
+                {
+                    Title = "PxGraf",
+                    Version = "v1",
+                    Description = "API for creating and serving statistical visualizations from PX data sources."
+                };
+                c.SwaggerDoc(swaggerDocName, apiInfo);
                 try
                 {
                     c.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, "PxGraf.xml"));
@@ -237,15 +240,14 @@ namespace PxGraf
                 app.UseDeveloperExceptionPage();
             }
 
-            // Swagger requires this seemingly redundant setup to work properly with a custom api route prefix.
             app.UseSwagger(c =>
             {
-                c.RouteTemplate = "{documentName}/swagger/swagger.json";
+                c.RouteTemplate = "/{documentName}/document.json";
             });
             app.UseSwaggerUI(c =>
             {
-                c.SwaggerEndpoint("swagger.json", "PxGraf");
-                c.RoutePrefix = $"{swaggerDocName}/swagger";
+                c.SwaggerEndpoint("openapi/document.json", "PxGraf");
+                c.RoutePrefix = string.Empty;
             });
 
             app.UseExceptionHandler("/api/error");

--- a/UnitTests/ConfigurationTests/ApiExplorerConventionsTests.cs
+++ b/UnitTests/ConfigurationTests/ApiExplorerConventionsTests.cs
@@ -103,23 +103,23 @@ namespace UnitTests.ConfigurationTests
         // Test controller types for attribute detection
         private class UngatedController
         {
-#pragma warning disable S1144 // Mark members as static
+#pragma warning disable S1144,S3218,CA1822 // Mark members as static
             public void FakeAction()
             {
                 // Method intentionally left empty.
             }
-#pragma warning restore S1144 // Mark members as static
+#pragma warning restore S1144,S3218,CA1822 // Mark members as static
         }
 
         [FeatureGate("CreationAPI")]
         private class GatedController
         {
-#pragma warning disable S1144 // Mark members as static
+#pragma warning disable S1144,S3218,CA1822 // Mark members as static
             public void FakeAction()
             {
                 // Method intentionally left empty.
             }
-#pragma warning restore S1144 // Mark members as static
+#pragma warning restore S1144,S3218,CA1822 // Mark members as static
         }
     }
 }

--- a/UnitTests/ConfigurationTests/ApiExplorerConventionsTests.cs
+++ b/UnitTests/ConfigurationTests/ApiExplorerConventionsTests.cs
@@ -1,0 +1,125 @@
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.Extensions.Configuration;
+using Microsoft.FeatureManagement.Mvc;
+using NUnit.Framework;
+using PxGraf.Settings;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace UnitTests.ConfigurationTests
+{
+    [TestFixture]
+    internal class ApiExplorerConventionsTests
+    {
+        private ApiExplorerConventions _conventions;
+
+        [SetUp]
+        public void Setup()
+        {
+            _conventions = new ApiExplorerConventions();
+        }
+
+        private static ActionModel CreateActionModel(Type controllerType, string methodName = "FakeAction", bool? initialVisibility = true)
+        {
+            ControllerModel controllerModel = new(controllerType.GetTypeInfo(), controllerType.GetCustomAttributes(inherit: true))
+            {
+                ControllerName = controllerType.Name
+            };
+
+            MethodInfo methodInfo = controllerType.GetMethod(methodName) ?? typeof(ApiExplorerConventionsTests).GetMethod(nameof(FakeAction));
+            ActionModel action = new(methodInfo, methodInfo.GetCustomAttributes(inherit: true))
+            {
+                ActionName = methodName,
+                Controller = controllerModel
+            };
+
+            action.ApiExplorer.IsVisible = initialVisibility;
+            return action;
+        }
+
+        // Dummy action method used for reflection when the controller type has no matching method
+        public static void FakeAction()
+        {
+            // Method intentionally left empty.
+        }
+
+        [Test]
+        public void Apply_NullVisibility_SetsHidden()
+        {
+            ActionModel action = CreateActionModel(typeof(UngatedController), initialVisibility: null);
+
+            _conventions.Apply(action);
+
+            Assert.That(action.ApiExplorer.IsVisible, Is.False);
+        }
+
+        [Test]
+        public void Apply_UngatedController_StaysVisible()
+        {
+            ActionModel action = CreateActionModel(typeof(UngatedController));
+
+            _conventions.Apply(action);
+
+            Assert.That(action.ApiExplorer.IsVisible, Is.True);
+        }
+
+        [Test]
+        public void Apply_GatedControllerWithFeatureEnabled_StaysVisible()
+        {
+            LoadConfigWithCreationAPI(true);
+            ActionModel action = CreateActionModel(typeof(GatedController));
+
+            _conventions.Apply(action);
+
+            Assert.That(action.ApiExplorer.IsVisible, Is.True);
+        }
+
+        [Test]
+        public void Apply_GatedControllerWithFeatureDisabled_SetsHidden()
+        {
+            LoadConfigWithCreationAPI(false);
+            ActionModel action = CreateActionModel(typeof(GatedController));
+
+            _conventions.Apply(action);
+
+            Assert.That(action.ApiExplorer.IsVisible, Is.False);
+        }
+
+        private static void LoadConfigWithCreationAPI(bool enabled)
+        {
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "DatabaseConfig:Type", "PxWeb" },
+                    { "DatabaseConfig:PxWebUrl", "http://test:1234/" },
+                    { "FeatureManagement:CreationAPI", enabled.ToString() }
+                })
+                .Build();
+
+            Configuration.Load(configuration);
+        }
+
+        // Test controller types for attribute detection
+        private class UngatedController
+        {
+#pragma warning disable S1144 // Mark members as static
+            public void FakeAction()
+            {
+                // Method intentionally left empty.
+            }
+#pragma warning restore S1144 // Mark members as static
+        }
+
+        [FeatureGate("CreationAPI")]
+        private class GatedController
+        {
+#pragma warning disable S1144 // Mark members as static
+            public void FakeAction()
+            {
+                // Method intentionally left empty.
+            }
+#pragma warning restore S1144 // Mark members as static
+        }
+    }
+}

--- a/UnitTests/ConfigurationTests/IsFeatureEnabledTests.cs
+++ b/UnitTests/ConfigurationTests/IsFeatureEnabledTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using PxGraf.Settings;
+using System.Collections.Generic;
+using UnitTests.Fixtures;
+
+namespace UnitTests.ConfigurationTests
+{
+    [TestFixture]
+    internal class IsFeatureEnabledTests
+    {
+        private static void LoadConfigWithCreationAPI(bool enabled)
+        {
+            Dictionary<string, string> config = TestInMemoryConfiguration.Get();
+            config["FeatureManagement:CreationAPI"] = enabled.ToString();
+
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(config)
+                .Build();
+
+            Configuration.Load(configuration);
+        }
+
+        [Test]
+        public void IsFeatureEnabled_CreationAPIEnabled_ReturnsTrue()
+        {
+            LoadConfigWithCreationAPI(true);
+
+            Assert.That(Configuration.Current.IsFeatureEnabled("CreationAPI"), Is.True);
+        }
+
+        [Test]
+        public void IsFeatureEnabled_CreationAPIDisabled_ReturnsFalse()
+        {
+            LoadConfigWithCreationAPI(false);
+
+            Assert.That(Configuration.Current.IsFeatureEnabled("CreationAPI"), Is.False);
+        }
+
+        [Test]
+        public void IsFeatureEnabled_UnknownFeature_ReturnsTrue()
+        {
+            LoadConfigWithCreationAPI(true);
+
+            Assert.That(Configuration.Current.IsFeatureEnabled("NonExistentFeature"), Is.True);
+        }
+
+        [Test]
+        public void IsFeatureEnabled_CaseInsensitive_ReturnsCorrectResult()
+        {
+            LoadConfigWithCreationAPI(true);
+
+            Assert.That(Configuration.Current.IsFeatureEnabled("creationapi"), Is.True);
+            Assert.That(Configuration.Current.IsFeatureEnabled("CREATIONAPI"), Is.True);
+        }
+    }
+}

--- a/UnitTests/ControllerTests/InfoControllerTests.cs
+++ b/UnitTests/ControllerTests/InfoControllerTests.cs
@@ -1,0 +1,86 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using PxGraf.Controllers;
+using PxGraf.Models.Responses;
+
+namespace UnitTests.ControllerTests
+{
+    [TestFixture]
+    internal class InfoControllerTests
+    {
+        private Mock<IWebHostEnvironment> _mockEnv;
+        private Mock<ILogger<InfoController>> _mockLogger;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockEnv = new Mock<IWebHostEnvironment>();
+            _mockEnv.Setup(e => e.ApplicationName).Returns("PxGraf");
+            _mockEnv.Setup(e => e.EnvironmentName).Returns("Development");
+            _mockLogger = new Mock<ILogger<InfoController>>();
+        }
+
+        [Test]
+        public void Get_ReturnsOkWithInfoResponse()
+        {
+            // Arrange
+            InfoController controller = new(_mockEnv.Object, _mockLogger.Object);
+
+            // Act
+            IActionResult result = controller.Get();
+
+            // Assert
+            Assert.That(result, Is.TypeOf<OkObjectResult>());
+            OkObjectResult okResult = (OkObjectResult)result;
+            Assert.That(okResult.Value, Is.TypeOf<InfoResponse>());
+        }
+
+        [Test]
+        public void Get_ResponseContainsCorrectName()
+        {
+            // Arrange
+            InfoController controller = new(_mockEnv.Object, _mockLogger.Object);
+
+            // Act
+            IActionResult result = controller.Get();
+
+            // Assert
+            OkObjectResult okResult = (OkObjectResult)result;
+            InfoResponse response = (InfoResponse)okResult.Value;
+            Assert.That(response.Name, Is.EqualTo("PxGraf"));
+        }
+
+        [Test]
+        public void Get_ResponseContainsCorrectEnvironment()
+        {
+            // Arrange
+            InfoController controller = new(_mockEnv.Object, _mockLogger.Object);
+
+            // Act
+            IActionResult result = controller.Get();
+
+            // Assert
+            OkObjectResult okResult = (OkObjectResult)result;
+            InfoResponse response = (InfoResponse)okResult.Value;
+            Assert.That(response.Environment, Is.EqualTo("Development"));
+        }
+
+        [Test]
+        public void Get_ResponseContainsVersion()
+        {
+            // Arrange
+            InfoController controller = new(_mockEnv.Object, _mockLogger.Object);
+
+            // Act
+            IActionResult result = controller.Get();
+
+            // Assert
+            OkObjectResult okResult = (OkObjectResult)result;
+            InfoResponse response = (InfoResponse)okResult.Value;
+            Assert.That(response.Version, Is.Not.Null);
+        }
+    }
+}


### PR DESCRIPTION
- Add [ProducesResponseType] to controllers for accurate OpenAPI docs
- Refactor ApiExplorerConventions to support feature-flag-based visibility using [FeatureGate]
- Add Configuration.IsFeatureEnabled for feature flag checks
- Replace InfoController anonymous response with InfoResponse record
- Update Swagger setup: new doc name, root UI, improved description
- Remove default Swagger launch URL from launchSettings.json
- Remove unused package and XML doc generation from csproj
- Add unit tests for feature gating, InfoController, and config
- Add necessary using directives for new attributes and types