### PR TITLE
[Hotfix] Refactor JSON deserialization to use stream-based method

### DIFF
--- a/PxGraf/Utility/SqFileInterface.cs
+++ b/PxGraf/Utility/SqFileInterface.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using PxGraf.Settings;
 using PxGraf.Storage;
+using System.IO;
 
 namespace PxGraf.Utility
 {
@@ -85,8 +86,8 @@ namespace PxGraf.Utility
         /// <returns></returns>
         private static async Task<T> ReadJsonObjectFromFileImpl<T>(IStorageProvider storage, string path)
         {
-            string respdata = await storage.ReadAllTextAsync(path);
-            return JsonSerializer.Deserialize<T>(respdata, GlobalJsonConverterOptions.Default)
+            Stream stream = await storage.OpenReadAsync(path);
+            return await JsonSerializer.DeserializeAsync<T>(stream, GlobalJsonConverterOptions.Default)
                 ?? throw new JsonException($"Failed to deserialize object from {path}");
         }
 

--- a/PxGraf/Utility/SqFileInterface.cs
+++ b/PxGraf/Utility/SqFileInterface.cs
@@ -86,7 +86,7 @@ namespace PxGraf.Utility
         /// <returns></returns>
         private static async Task<T> ReadJsonObjectFromFileImpl<T>(IStorageProvider storage, string path)
         {
-            Stream stream = await storage.OpenReadAsync(path);
+            using Stream stream = await storage.OpenReadAsync(path);
             return await JsonSerializer.DeserializeAsync<T>(stream, GlobalJsonConverterOptions.Default)
                 ?? throw new JsonException($"Failed to deserialize object from {path}");
         }


### PR DESCRIPTION
Updated the file reading logic to use OpenReadAsync and JsonSerializer.DeserializeAsync<T> for deserializing JSON objects directly from a stream. This uses the default encoding detection for the UTF-8 query files. The previous implementation used the read method meant for the alias files that can have strange encodings, but the encoding checker only read small section from the start of the file.