### PR TITLE
Update versions, error handling, and Swagger config

### DIFF
--- a/PxGraf.Frontend/package-lock.json
+++ b/PxGraf.Frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pxgraf",
-  "version": "2.5.14",
+  "version": "2.5.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pxgraf",
-      "version": "2.5.14",
+      "version": "2.5.15",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/PxGraf.Frontend/package-lock.json
+++ b/PxGraf.Frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pxgraf",
-  "version": "2.5.13",
+  "version": "2.5.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pxgraf",
-      "version": "2.5.13",
+      "version": "2.5.14",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/PxGraf.Frontend/package.json
+++ b/PxGraf.Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxgraf",
-  "version": "2.5.14",
+  "version": "2.5.15",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/PxGraf.Frontend/src/components/SaveResultDialog/SaveResultDialog.test.tsx
+++ b/PxGraf.Frontend/src/components/SaveResultDialog/SaveResultDialog.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SaveResultDialog from './SaveResultDialog';
 import { EQueryPublicationStatus } from "types/saveQuery";
-import { ISaveQueryResult } from 'api/services/queries';
+import { ISaveQueryMutationParams, ISaveQueryResult } from 'api/services/queries';
 
 
 const mockSuccessMutation: ISaveQueryResult = {
@@ -11,9 +11,7 @@ const mockSuccessMutation: ISaveQueryResult = {
     isError: false,
     isSuccess: true,
     data: { id: 'foobar', publicationStatus: EQueryPublicationStatus.Success },
-    mutate: function (_property: any): void {
-        throw new Error('Function not implemented.');
-    }
+    mutate: jest.fn<void, [ISaveQueryMutationParams]>()
 };
 
 const mockSuccessDraftMutation: ISaveQueryResult = {
@@ -21,9 +19,7 @@ const mockSuccessDraftMutation: ISaveQueryResult = {
     isError: false,
     isSuccess: true,
     data: { id: 'foobar', publicationStatus: EQueryPublicationStatus.Unpublished },
-    mutate: function (_property: any): void {
-        throw new Error('Function not implemented.');
-    }
+    mutate: jest.fn<void, [ISaveQueryMutationParams]>()
 };
 
 const mockFailedPublicationMutation: ISaveQueryResult = {
@@ -31,9 +27,7 @@ const mockFailedPublicationMutation: ISaveQueryResult = {
     isError: false,
     isSuccess: true,
     data: { id: 'foobar', publicationStatus: EQueryPublicationStatus.Failed },
-    mutate: function (_property: any): void {
-        throw new Error('Function not implemented.');
-    }
+    mutate: jest.fn<void, [ISaveQueryMutationParams]>()
 };
 
 const mockRequestErrorMutation: ISaveQueryResult = {
@@ -41,9 +35,7 @@ const mockRequestErrorMutation: ISaveQueryResult = {
     isError: true,
     isSuccess: false,
     data: null,
-    mutate: function (_property: any): void {
-        throw new Error('Function not implemented.');
-    }
+    mutate: jest.fn<void, [ISaveQueryMutationParams]>()
 };
 
 const onCloseMock = jest.fn();

--- a/PxGraf.Frontend/src/components/SaveResultDialog/SaveResultDialog.test.tsx
+++ b/PxGraf.Frontend/src/components/SaveResultDialog/SaveResultDialog.test.tsx
@@ -26,11 +26,21 @@ const mockSuccessDraftMutation: ISaveQueryResult = {
     }
 };
 
-const mockErrorMutation: ISaveQueryResult = {
+const mockFailedPublicationMutation: ISaveQueryResult = {
     isPending: false,
     isError: false,
     isSuccess: true,
     data: { id: 'foobar', publicationStatus: EQueryPublicationStatus.Failed },
+    mutate: function (_property: any): void {
+        throw new Error('Function not implemented.');
+    }
+};
+
+const mockRequestErrorMutation: ISaveQueryResult = {
+    isPending: false,
+    isError: true,
+    isSuccess: false,
+    data: null,
     mutate: function (_property: any): void {
         throw new Error('Function not implemented.');
     }
@@ -70,10 +80,19 @@ describe('Rendering test', () => {
     });
 });
 
-describe('Error rendering test', () => {
-    it('renders error correctly when open with error', () => {
+describe('Failed publication status rendering test', () => {
+    it('renders correctly when publication status is Failed', () => {
         const dom = render(
-                <SaveResultDialog mutation={mockErrorMutation} onClose={onCloseMock} open={true} />
+                <SaveResultDialog mutation={mockFailedPublicationMutation} onClose={onCloseMock} open={true} />
+        );
+        expect(dom.baseElement).toMatchSnapshot();
+    });
+});
+
+describe('Request error rendering test', () => {
+    it('renders correctly when request isError is true', () => {
+        const dom = render(
+                <SaveResultDialog mutation={mockRequestErrorMutation} onClose={onCloseMock} open={true} />
         );
         expect(dom.baseElement).toMatchSnapshot();
     });

--- a/PxGraf.Frontend/src/components/SaveResultDialog/__snapshots__/SaveResultDialog.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/SaveResultDialog/__snapshots__/SaveResultDialog.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Error rendering test renders error correctly when open with error 1`] = `
+exports[`Failed publication status rendering test renders correctly when publication status is Failed 1`] = `
 <body
   style="padding-right: 1024px; overflow: hidden;"
 >
@@ -548,6 +548,99 @@ exports[`Rendering test renders correctly when open with publication disabled 1`
               class="MuiAlert-message css-zioonp-MuiAlert-message"
             >
               saveResultDialog.webhookResponseSuccess
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiDialogActions-root MuiDialogActions-spacing css-15fu35s-MuiDialogActions-root"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-74d805-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            saveResultDialog.ok
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
+exports[`Request error rendering test renders correctly when request isError is true 1`] = `
+<body
+  style="padding-right: 1024px; overflow: hidden;"
+>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiDialog-root MuiModal-root css-1424xw8-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiModal-backdrop MuiDialog-backdrop css-1cennmq-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-19do60a-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-describedby="scroll-dialog-description"
+        aria-labelledby="scroll-dialog-title"
+        aria-modal="true"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm css-10d30g3-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+        style="--Paper-shadow: 0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12);"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-rvoa5x-MuiTypography-root-MuiDialogTitle-root"
+          id="result-dialog-title"
+        >
+          saveResultDialog.fail
+        </h2>
+        <div
+          class="MuiDialogContent-root MuiDialogContent-dividers css-10bxh4q-MuiDialogContent-root"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorError MuiAlert-standardError MuiAlert-standard css-3lhuho-MuiPaper-root-MuiAlert-root"
+            role="alert"
+            style="--Paper-shadow: none;"
+          >
+            <div
+              class="MuiAlert-icon css-vab54s-MuiAlert-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1ckov0h-MuiSvgIcon-root"
+                data-testid="ErrorOutlineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiAlert-message css-zioonp-MuiAlert-message"
+            >
+               
+              saveResultDialog.errorMessage
+               
             </div>
           </div>
         </div>

--- a/PxGraf.Frontend/src/hooks/useReplaceQueryParams.ts
+++ b/PxGraf.Frontend/src/hooks/useReplaceQueryParams.ts
@@ -9,13 +9,15 @@ const useReplaceQueryParams = (path: string): void => {
     const { tablePath } = useNavigationContext();
     const tablePathParams = useHierarchyParams();
 
-    const shouldReplace = Boolean(tablePath?.length) && tablePath.join(',') !== tablePathParams?.join(',');
+    const tablePathKey = tablePath?.join(',') ?? '';
+    const tablePathParamsKey = tablePathParams?.join(',') ?? '';
+    const shouldReplace = Boolean(tablePath?.length) && tablePathKey !== tablePathParamsKey;
 
     useEffect(() => {
         if(shouldReplace) {
-            navigate({pathname: path, search: `?tablePath=${tablePath.join(',')}`}, { replace: true });
+            navigate({pathname: path, search: `?tablePath=${tablePathKey}`}, { replace: true });
         }
-    }, [navigate, path, routerLocation, shouldReplace]);
+    }, [navigate, path, routerLocation, shouldReplace, tablePathKey, tablePathParamsKey]);
 }
 
 export default useReplaceQueryParams;

--- a/PxGraf.Frontend/tsconfig.json
+++ b/PxGraf.Frontend/tsconfig.json
@@ -5,7 +5,7 @@
     "jsx": "react",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2016",
+    "target": "ES2022",
     "module": "ES2020",
     "moduleResolution": "node",
     "noEmit": true,

--- a/PxGraf/PxGraf.csproj
+++ b/PxGraf/PxGraf.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>PxGraf</AssemblyName>
     <UserSecretsId>5fefcbdc-e04e-4475-9927-aab412b027ff</UserSecretsId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>4.8.1</VersionPrefix>
+    <VersionPrefix>4.8.2</VersionPrefix>
 	<SpaRoot>..\PxGraf.Frontend</SpaRoot>
 	<Configurations>Debug;Release;Test</Configurations>
   </PropertyGroup>

--- a/PxGraf/Services/PublicationWebhookService.cs
+++ b/PxGraf/Services/PublicationWebhookService.cs
@@ -100,8 +100,7 @@ namespace PxGraf.Services
 
                     logger.LogInformation("Sending publication webhook for query to {WebhookUrl}", _config.WebhookUrl);
 
-                    HttpResponseMessage response = await httpClient.SendAsync(request);
-
+                    using HttpResponseMessage response = await httpClient.SendAsync(request);
                     MultilanguageString messages = await ExtractMessagesFromResponse(response);
 
                     if (response.IsSuccessStatusCode)
@@ -330,11 +329,12 @@ namespace PxGraf.Services
                     request.Headers.Add(_config.AccessTokenHeaderName, _config.AccessTokenHeaderValue);
                 }
 
-                HttpResponseMessage response = await httpClient.SendAsync(request);
+                using HttpResponseMessage response = await httpClient.SendAsync(request);
                 return response.IsSuccessStatusCode;
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
+                logger.LogDebug(ex, "Unexpected error while checking publication webhook reachability.");
                 return false;
             }
         }

--- a/PxGraf/Startup.cs
+++ b/PxGraf/Startup.cs
@@ -242,7 +242,7 @@ namespace PxGraf
 
             app.UseSwagger(c =>
             {
-                c.RouteTemplate = "/{documentName}/document.json";
+                c.RouteTemplate = "{documentName}/document.json";
             });
             app.UseSwaggerUI(c =>
             {


### PR DESCRIPTION
- Bump frontend version to 2.5.15 and backend version to 4.8.2
- Refactor SaveResultDialog tests: split error cases, add mocks, update snapshots
- Improve useReplaceQueryParams: handle null/undefined, fix effect deps
- Use 'using' for HttpResponseMessage, add debug log in PublicationWebhookService
- Fix Swagger route template in Startup.cs
- Update TypeScript target to ES2022 in tsconfig.json