### PR TITLE
[Security] Security hardening, npm audit fixes, and nlog config corrections

### DIFF
--- a/PxGraf.Frontend/package-lock.json
+++ b/PxGraf.Frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pxgraf",
-  "version": "2.5.15",
+  "version": "2.5.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pxgraf",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/PxGraf.Frontend/package-lock.json
+++ b/PxGraf.Frontend/package-lock.json
@@ -45,7 +45,7 @@
         "jest": "^30.3.0",
         "jest-editor-support": "^32.0.0-beta.1",
         "jest-environment-jsdom": "^30.3.0",
-        "jest-junit": "^16.0.0",
+        "jest-junit": "^17.0.0",
         "jest-sonar-reporter": "^2.0.0",
         "jsdom": "^29.0.0",
         "ts-jest": "^29.4.6",
@@ -1108,9 +1108,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1189,9 +1189,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3226,12 +3226,6 @@
         "csstype": "^3.2.2"
       }
     },
-    "node_modules/@types/stylis": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
-      "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
-      "license": "MIT"
-    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -4259,9 +4253,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5524,9 +5518,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5619,9 +5613,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6195,9 +6189,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8020,19 +8014,19 @@
       }
     },
     "node_modules/jest-junit": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
-      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-17.0.0.tgz",
+      "integrity": "sha512-RYWCkq4j59gUXj5DsgbIE7xFBZzu1gtibPhyjSjMmGaOTLnqlXhg7x9zuGCwgbCuMAyoyvk0Mi8wSrRR5uOeLA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "mkdirp": "^1.0.4",
         "strip-ansi": "^6.0.1",
-        "uuid": "^8.3.2",
+        "uuid": "^14.0.0",
         "xml": "^1.0.1"
       },
       "engines": {
-        "node": ">=10.12.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/jest-junit/node_modules/strip-ansi": {
@@ -9257,9 +9251,10 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9827,9 +9822,10 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9846,7 +9842,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10384,12 +10380,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "license": "MIT"
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -10536,6 +10526,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -10875,20 +10866,15 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.11.tgz",
-      "integrity": "sha512-opzgceGlQ5rdZdGwf9ddLW7EM2F4L7tgsgLn6fFzQ2JgE5EVQ4HZwNkcgB1p8WfOBx1GEZP3fa66ajJmtXhSrA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.2.tgz",
+      "integrity": "sha512-xZBhBJsMtGqb+aKcwKgaT+BtuFums9VynX2JRvXJGTx5UfZzN12rk5r4nVdhXYvRw+hE7yiYxVrOqJZaK2+Txg==",
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
-        "@emotion/unitless": "0.10.0",
-        "@types/stylis": "4.2.7",
         "css-to-react-native": "3.2.0",
         "csstype": "3.2.3",
-        "postcss": "8.4.49",
-        "shallowequal": "1.1.0",
-        "stylis": "4.3.6",
-        "tslib": "2.8.1"
+        "stylis": "4.3.6"
       },
       "engines": {
         "node": ">= 16"
@@ -10898,11 +10884,19 @@
         "url": "https://opencollective.com/styled-components"
       },
       "peerDependencies": {
+        "css-to-react-native": ">= 3.2.0",
         "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0"
+        "react-dom": ">= 16.8.0",
+        "react-native": ">= 0.68.0"
       },
       "peerDependenciesMeta": {
+        "css-to-react-native": {
+          "optional": true
+        },
         "react-dom": {
+          "optional": true
+        },
+        "react-native": {
           "optional": true
         }
       }
@@ -10997,9 +10991,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11273,6 +11267,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -11539,13 +11534,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -11683,35 +11682,6 @@
       },
       "peerDependencies": {
         "vite": "*"
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/void-elements": {
@@ -12030,9 +12000,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/PxGraf.Frontend/package.json
+++ b/PxGraf.Frontend/package.json
@@ -8,6 +8,7 @@
     "@mui/icons-material": "^7.3.9",
     "@mui/material": "^7.0.2",
     "@statisticsfinland/pxvisualizer": "^1.4.5",
+    "@tanstack/react-query": "^5.90.21",
     "@types/lodash": "^4.17.24",
     "@types/styled-components": "^5.1.36",
     "i18next": "^25.8.18",
@@ -18,8 +19,7 @@
     "react-i18next": "^16.5.8",
     "react-router-dom": "^7.13.1",
     "styled-components": "^6.3.11",
-    "web-vitals": "^5.1.0",
-    "@tanstack/react-query": "^5.90.21"
+    "web-vitals": "^5.1.0"
   },
   "scripts": {
     "start": "vite",
@@ -65,7 +65,7 @@
     "jest": "^30.3.0",
     "jest-editor-support": "^32.0.0-beta.1",
     "jest-environment-jsdom": "^30.3.0",
-    "jest-junit": "^16.0.0",
+    "jest-junit": "^17.0.0",
     "jest-sonar-reporter": "^2.0.0",
     "jsdom": "^29.0.0",
     "ts-jest": "^29.4.6",

--- a/PxGraf.Frontend/package.json
+++ b/PxGraf.Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxgraf",
-  "version": "2.5.15",
+  "version": "2.5.16",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/PxGraf.Frontend/src/components/Header/__snapshots__/Header.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/Header/__snapshots__/Header.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Header component should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-dhKdcy gOejqN MuiBox-root css-0"
+    class="sc-jrIDTr jtSWkG MuiBox-root css-0"
   >
     <div
-      class="MuiStack-root sc-dAlyuI fXJanr css-m69qwo-MuiStack-root"
+      class="MuiStack-root sc-iqkkDd gqUbQC css-m69qwo-MuiStack-root"
     >
       <a
         class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary Mui-focusVisible MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-65lmr2-MuiButtonBase-root-MuiButton-root"
@@ -23,12 +23,12 @@ exports[`Header component should render correctly 1`] = `
       >
         <img
           alt="navbar.logoAlt"
-          class="sc-jXbUNf iMYAsu"
+          class="sc-qdQOe cIeTM"
           src="test-file-stub"
         />
       </a>
       <div
-        class="sc-cwHptO hmWtzT"
+        class="sc-dYjPD iUOpRe"
       >
         <h1
           class="MuiTypography-root MuiTypography-h1 css-10l7o3s-MuiTypography-root"
@@ -37,7 +37,7 @@ exports[`Header component should render correctly 1`] = `
         </h1>
       </div>
       <div
-        class="sc-jlZhev hQXPWc"
+        class="sc-crPgjm hILzSH"
       >
         <a
           class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1uent87-MuiButtonBase-root-MuiButton-root"
@@ -55,22 +55,22 @@ exports[`Header component should render correctly 1`] = `
         </button>
       </div>
       <div
-        class="MuiStack-root sc-kpDqfp bPPoxz css-1os650h-MuiStack-root"
+        class="MuiStack-root sc-kEbgWM hGPUgb css-1os650h-MuiStack-root"
       >
         <div
-          class="MuiStack-root sc-dcJsrX NUDEH css-nen11g-MuiStack-root"
+          class="MuiStack-root sc-eCQgVK clVryv css-nen11g-MuiStack-root"
         >
           <div
-            class="sc-gsFSXt hZiSxo"
+            class="sc-gKkgUA oaXWM"
           >
             <p
-              class="MuiTypography-root MuiTypography-body2 sc-iGgWBk VAxoQ css-1wle3ir-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body2 sc-jSppWd iemUHM css-1wle3ir-MuiTypography-root"
             >
               general.uiLanguage
             </p>
             <button
               aria-label="tooltip.open: general.uiLanguage"
-              class="sc-gEvEes iyPTpc"
+              class="sc-gtcBCx gUCgDH"
             >
               <svg
                 aria-hidden="true"

--- a/PxGraf.Frontend/src/components/InfoBubble/__snapshots__/InfoBubble.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/InfoBubble/__snapshots__/InfoBubble.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Rendering test renders correctly with popper hidden 1`] = `
 <DocumentFragment>
   <button
     aria-label="tooltip.open: foo"
-    class="sc-aXZVf linXBE"
+    class="sc-bdDsCe fVRDsd"
   >
     <svg
       aria-hidden="true"

--- a/PxGraf.Frontend/src/components/LanguageSelector/__snapshots__/LanguageSelector.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/LanguageSelector/__snapshots__/LanguageSelector.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiStack-root sc-dcJsrX NUDEH css-nen11g-MuiStack-root"
+    class="MuiStack-root sc-eCQgVK clVryv css-nen11g-MuiStack-root"
   >
     <div
-      class="sc-gsFSXt hZiSxo"
+      class="sc-gKkgUA oaXWM"
     >
       <p
-        class="MuiTypography-root MuiTypography-body2 sc-iGgWBk VAxoQ css-1wle3ir-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body2 sc-jSppWd iemUHM css-1wle3ir-MuiTypography-root"
       >
         general.uiLanguage
       </p>
       <button
         aria-label="tooltip.open: general.uiLanguage"
-        class="sc-gEvEes iyPTpc"
+        class="sc-gtcBCx gUCgDH"
       >
         <svg
           aria-hidden="true"
@@ -35,19 +35,19 @@ exports[`Rendering test renders correctly 1`] = `
     >
       <a
         aria-label="general.uiLanguage: lang.fi"
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary sc-kAycey hOjiDe css-1ccsd5i-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary sc-iCECmn bufDcg css-1ccsd5i-MuiButtonBase-root-MuiButton-root"
         href="#"
         tabindex="0"
       >
         <p
-          class="MuiTypography-root MuiTypography-body1 sc-aXZVf eNbmYZ css-rizt0-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 sc-bdDsCe hdpaPw css-rizt0-MuiTypography-root"
         >
           FI
         </p>
       </a>
       <a
         aria-label="general.uiLanguage: lang.en"
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary sc-kAycey hOjiDe css-1ccsd5i-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary sc-iCECmn bufDcg css-1ccsd5i-MuiButtonBase-root-MuiButton-root"
         href="#"
         tabindex="0"
       >
@@ -59,7 +59,7 @@ exports[`Rendering test renders correctly 1`] = `
       </a>
       <a
         aria-label="general.uiLanguage: lang.sv"
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary sc-kAycey hOjiDe css-1ccsd5i-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary sc-iCECmn bufDcg css-1ccsd5i-MuiButtonBase-root-MuiButton-root"
         href="#"
         tabindex="0"
       >

--- a/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/BasicDimensionEditor.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/BasicDimensionEditor.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiStack-root sc-gEvEes iNpFeY css-1sazv7p-MuiStack-root"
+    class="MuiStack-root sc-gtcBCx ctcITL css-1sazv7p-MuiStack-root"
   >
     <div
       class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
@@ -18,7 +18,7 @@ exports[`Rendering test renders correctly 1`] = `
         </b>
       </label>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf djJESr css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe fBqFXC css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <input
           aria-invalid="false"

--- a/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/ContentDimensionEditor.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/ContentDimensionEditor.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Rendering test renders correctly 1`] = `
         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-i9zgug-MuiPaper-root"
       >
         <div
-          class="MuiStack-root sc-gEvEes ihHurX css-1sazv7p-MuiStack-root"
+          class="MuiStack-root sc-gtcBCx bYBAVY css-1sazv7p-MuiStack-root"
         >
           <div
             class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
@@ -27,7 +27,7 @@ exports[`Rendering test renders correctly 1`] = `
               </b>
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf djJESr css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe fBqFXC css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
@@ -92,7 +92,7 @@ exports[`Rendering test renders correctly 1`] = `
               editMetadata.unit
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-aXZVf lmnYlB css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-bdDsCe iQwuvs css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
@@ -129,7 +129,7 @@ exports[`Rendering test renders correctly 1`] = `
               editMetadata.source
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-aXZVf lmnYlB css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-bdDsCe iQwuvs css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"

--- a/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/ContentDimensionValueEditor.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/ContentDimensionValueEditor.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Rendering test renders correctly 1`] = `
     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-i9zgug-MuiPaper-root"
   >
     <div
-      class="MuiStack-root sc-gEvEes ihHurX css-1sazv7p-MuiStack-root"
+      class="MuiStack-root sc-gtcBCx bYBAVY css-1sazv7p-MuiStack-root"
     >
       <div
         class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
@@ -19,7 +19,7 @@ exports[`Rendering test renders correctly 1`] = `
           editMetadata.valueName: asd
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-aXZVf lmnYlB css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-bdDsCe iQwuvs css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
@@ -56,7 +56,7 @@ exports[`Rendering test renders correctly 1`] = `
           editMetadata.unit
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-aXZVf lmnYlB css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-bdDsCe iQwuvs css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
@@ -93,7 +93,7 @@ exports[`Rendering test renders correctly 1`] = `
           editMetadata.source
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-aXZVf lmnYlB css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-bdDsCe iQwuvs css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"

--- a/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/DimensionEditor.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/DimensionEditor.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Rendering test renders correctly 1`] = `
         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-i9zgug-MuiPaper-root"
       >
         <div
-          class="MuiStack-root sc-gEvEes ihHurX css-1sazv7p-MuiStack-root"
+          class="MuiStack-root sc-gtcBCx bYBAVY css-1sazv7p-MuiStack-root"
         >
           <div
             class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
@@ -27,7 +27,7 @@ exports[`Rendering test renders correctly 1`] = `
               </b>
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf djJESr css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe fBqFXC css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
@@ -92,7 +92,7 @@ exports[`Rendering test renders correctly 1`] = `
               editMetadata.unit
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-aXZVf lmnYlB css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-bdDsCe iQwuvs css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
@@ -129,7 +129,7 @@ exports[`Rendering test renders correctly 1`] = `
               editMetadata.source
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-aXZVf lmnYlB css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-bdDsCe iQwuvs css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"

--- a/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/EditorField.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/EditorField.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Rendering test renders correctly 1`] = `
       </b>
     </label>
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf djJESr css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe fBqFXC css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
     >
       <input
         aria-invalid="false"
@@ -87,7 +87,7 @@ exports[`Rendering test renders correctly if limit close 1`] = `
       </b>
     </label>
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf djJESr css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe fBqFXC css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
     >
       <input
         aria-invalid="false"
@@ -186,7 +186,7 @@ exports[`Rendering test renders correctly if limit reached 1`] = `
       </b>
     </label>
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf djJESr css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe fBqFXC css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
     >
       <input
         aria-invalid="false"
@@ -285,7 +285,7 @@ exports[`Rendering test renders correctly if limit specified but values are shor
       </b>
     </label>
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf djJESr css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe fBqFXC css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
     >
       <input
         aria-invalid="false"
@@ -355,7 +355,7 @@ exports[`Rendering test renders correctly if the value hsa not been edited 1`] =
       label
     </label>
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-aXZVf lmnYlB css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-bdDsCe iQwuvs css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
     >
       <input
         aria-invalid="false"

--- a/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/HeaderEditor.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/HeaderEditor.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-iGgWBk eLJcbZ"
+    class="sc-jSppWd hALHgh"
   >
     <div
-      class="sc-dcJsrX cMSwT"
+      class="sc-eCQgVK fLnhcr"
     >
       <button
         aria-label="tooltip.open: editMetadata.header"
-        class="sc-gEvEes iyPTpc"
+        class="sc-gtcBCx gUCgDH"
       >
         <svg
           aria-hidden="true"
@@ -37,7 +37,7 @@ exports[`Rendering test renders correctly 1`] = `
           </b>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf djJESr css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe fBqFXC css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"

--- a/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/MetaEditor.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/MetaEditor/__snapshots__/MetaEditor.test.tsx.snap
@@ -3,17 +3,17 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-kpDqfp kCKSnF MuiBox-root css-0"
+    class="sc-kEbgWM jqaMqF MuiBox-root css-0"
   >
     <div
-      class="sc-dhKdcy elZQdn"
+      class="sc-jrIDTr gVSSYU"
     >
       <div
-        class="sc-jXbUNf cEYnqm"
+        class="sc-qdQOe jOquNE"
       >
         <button
           aria-label="tooltip.open: editMetadata.header"
-          class="sc-gsFSXt jMCyKe"
+          class="sc-gKkgUA iAMuGy"
         >
           <svg
             aria-hidden="true"
@@ -41,7 +41,7 @@ exports[`Rendering test renders correctly 1`] = `
             </b>
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-gEvEes jnzMHb css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-gtcBCx ihMbbA css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
@@ -98,14 +98,14 @@ exports[`Rendering test renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-cPiKLY hbJcxi"
+      class="sc-krVzYl jzidJz"
     >
       <div
-        class="sc-jEACwF jclZoL"
+        class="sc-bqqMSY itQibn"
       >
         <button
           aria-label="tooltip.open: editMetadata.editorTitle"
-          class="sc-gsFSXt jMCyKe"
+          class="sc-gKkgUA iAMuGy"
         >
           <svg
             aria-hidden="true"
@@ -120,7 +120,7 @@ exports[`Rendering test renders correctly 1`] = `
           </svg>
         </button>
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-dAlyuI cPIluc css-1808mag-MuiPaper-root-MuiAccordion-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-iqkkDd gMOKrp css-1808mag-MuiPaper-root-MuiAccordion-root"
           style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
         >
           <h3
@@ -178,10 +178,10 @@ exports[`Rendering test renders correctly 1`] = `
                   role="region"
                 >
                   <div
-                    class="MuiAccordionDetails-root sc-dLMFT frypaN css-1lj39kh-MuiAccordionDetails-root"
+                    class="MuiAccordionDetails-root sc-hCcPtG rnJdY css-1lj39kh-MuiAccordionDetails-root"
                   >
                     <div
-                      class="sc-jlZhev hxqCKM MuiBox-root css-1mc6bnb"
+                      class="sc-crPgjm bHMEA-D MuiBox-root css-1mc6bnb"
                     >
                       <div
                         class="MuiTabs-root css-jhczcq-MuiTabs-root"
@@ -225,7 +225,7 @@ exports[`Rendering test renders correctly 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-cwHptO fjpGx MuiBox-root css-0"
+                      class="sc-dYjPD KvxZA MuiBox-root css-0"
                     >
                       <div
                         aria-labelledby="simple-tab-0"
@@ -233,7 +233,7 @@ exports[`Rendering test renders correctly 1`] = `
                         role="tabpanel"
                       >
                         <div
-                          class="sc-aXZVf eSKBbS MuiBox-root css-0"
+                          class="sc-bdDsCe ewwDVL MuiBox-root css-0"
                         >
                           <div
                             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row MuiGrid-spacing-xs-3 css-1u8xl8z-MuiGrid-root"
@@ -245,7 +245,7 @@ exports[`Rendering test renders correctly 1`] = `
                                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-i9zgug-MuiPaper-root"
                               >
                                 <div
-                                  class="MuiStack-root sc-eqUAAB bIpVLn css-1sazv7p-MuiStack-root"
+                                  class="MuiStack-root sc-dkXsAU bZeLrJ css-1sazv7p-MuiStack-root"
                                 >
                                   <div
                                     class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
@@ -258,7 +258,7 @@ exports[`Rendering test renders correctly 1`] = `
                                       editMetadata.valueName: fgfgfg
                                     </label>
                                     <div
-                                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gEvEes imPffV css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+                                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtcBCx Dusne css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
                                     >
                                       <input
                                         aria-invalid="false"
@@ -295,7 +295,7 @@ exports[`Rendering test renders correctly 1`] = `
                                       editMetadata.unit
                                     </label>
                                     <div
-                                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gEvEes imPffV css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+                                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtcBCx Dusne css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
                                     >
                                       <input
                                         aria-invalid="false"
@@ -332,7 +332,7 @@ exports[`Rendering test renders correctly 1`] = `
                                       editMetadata.source
                                     </label>
                                     <div
-                                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gEvEes imPffV css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+                                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtcBCx Dusne css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
                                     >
                                       <input
                                         aria-invalid="false"

--- a/PxGraf.Frontend/src/components/NestedList/__snapshots__/NestedList.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/NestedList/__snapshots__/NestedList.test.tsx.snap
@@ -127,7 +127,7 @@ exports[`Rendering test renders correctly 1`] = `
     class="MuiDivider-root MuiDivider-fullWidth css-1jpc804-MuiDivider-root"
   />
   <li
-    class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-ibQAlc iaNOVO css-cfd5wn-MuiListItem-root"
+    class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-fbWTCR kMpNsR css-cfd5wn-MuiListItem-root"
     id="foo-bar-baz-asd2.px"
   >
     <a
@@ -179,7 +179,7 @@ exports[`Rendering test renders correctly when table query  1`] = `
     class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-cfd5wn-MuiListItem-root"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorError MuiAlert-standardError MuiAlert-standard sc-fTFjTL erESsa css-u8pub9-MuiPaper-root-MuiAlert-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorError MuiAlert-standardError MuiAlert-standard sc-eGZRwK ctfsYL css-u8pub9-MuiPaper-root-MuiAlert-root"
       role="alert"
       style="--Paper-shadow: none;"
     >
@@ -220,11 +220,11 @@ exports[`Rendering test renders correctly while loading data 1`] = `
       class="MuiListItemIcon-root css-1luiz03-MuiListItemIcon-root"
     >
       <span
-        class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse sc-guJBde LzpvH css-1epbneo-MuiSkeleton-root"
+        class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse sc-gtlXMD cglMsn css-1epbneo-MuiSkeleton-root"
       />
     </div>
     <div
-      class="MuiListItemText-root sc-hZDyAP guAjOO css-1suf81v-MuiListItemText-root"
+      class="MuiListItemText-root sc-bXuqjq eAsTVA css-1suf81v-MuiListItemText-root"
     >
       <span
         class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-rizt0-MuiTypography-root"

--- a/PxGraf.Frontend/src/components/NestedList/__snapshots__/TableItem.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/NestedList/__snapshots__/TableItem.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <li
-    class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-hZDyAP iFejxI css-cfd5wn-MuiListItem-root"
+    class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-bXuqjq dtLGsi css-cfd5wn-MuiListItem-root"
     id="foo-bar-baz"
   >
     <a

--- a/PxGraf.Frontend/src/components/Preview/__snapshots__/Preview.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/Preview/__snapshots__/Preview.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-  class="sc-dcJsrX cvUQts"
+  class="sc-eCQgVK hDcoKs"
 >
   <button
     aria-label="tooltip.open: tooltip.visualizationSize"
-    class="sc-aXZVf linXBE"
+    class="sc-bdDsCe fVRDsd"
   >
     <svg
       aria-hidden="true"
@@ -106,7 +106,7 @@ exports[`Rendering test renders correctly 1`] = `
   class="MuiStack-root css-pl8gqh-MuiStack-root"
 />
   <div
-  class="sc-iGgWBk fvSpmY tk-table"
+  class="sc-jSppWd cEFcHx tk-table"
 >
   <pre
     data-testid="Chart"

--- a/PxGraf.Frontend/src/components/SaveResultDialog/__snapshots__/LoadingDialogContent.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/SaveResultDialog/__snapshots__/LoadingDialogContent.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Rendering test renders correctly 1`] = `
     class="MuiDialogContent-root MuiDialogContent-dividers css-10bxh4q-MuiDialogContent-root"
   >
     <div
-      class="MuiContainer-root MuiContainer-maxWidthLg sc-aXZVf OzWEY css-5c1adp-MuiContainer-root"
+      class="MuiContainer-root MuiContainer-maxWidthLg sc-bdDsCe itrdzx css-5c1adp-MuiContainer-root"
     >
       <span
         class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-1wxecgq-MuiCircularProgress-root"

--- a/PxGraf.Frontend/src/components/SaveResultDialog/__snapshots__/SaveResultDialog.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/SaveResultDialog/__snapshots__/SaveResultDialog.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`Failed publication status rendering test renders correctly when publica
           class="MuiDialogContent-root MuiDialogContent-dividers css-10bxh4q-MuiDialogContent-root"
         >
           <div
-            class="MuiFormControl-root sc-gEvEes HwpMG css-1iw3t7y-MuiFormControl-root"
+            class="MuiFormControl-root sc-gtcBCx hoLdIB css-1iw3t7y-MuiFormControl-root"
           >
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
@@ -54,7 +54,7 @@ exports[`Failed publication status rendering test renders correctly when publica
               saveResultDialog.id
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf ccKimk css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe emeDgd css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
@@ -198,7 +198,7 @@ exports[`Rendering test renders correctly when open (draft) 1`] = `
           class="MuiDialogContent-root MuiDialogContent-dividers css-10bxh4q-MuiDialogContent-root"
         >
           <div
-            class="MuiFormControl-root sc-gEvEes HwpMG css-1iw3t7y-MuiFormControl-root"
+            class="MuiFormControl-root sc-gtcBCx hoLdIB css-1iw3t7y-MuiFormControl-root"
           >
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
@@ -208,7 +208,7 @@ exports[`Rendering test renders correctly when open (draft) 1`] = `
               saveResultDialog.id
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf ccKimk css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe emeDgd css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
@@ -320,7 +320,7 @@ exports[`Rendering test renders correctly when open 1`] = `
           class="MuiDialogContent-root MuiDialogContent-dividers css-10bxh4q-MuiDialogContent-root"
         >
           <div
-            class="MuiFormControl-root sc-gEvEes HwpMG css-1iw3t7y-MuiFormControl-root"
+            class="MuiFormControl-root sc-gtcBCx hoLdIB css-1iw3t7y-MuiFormControl-root"
           >
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
@@ -330,7 +330,7 @@ exports[`Rendering test renders correctly when open 1`] = `
               saveResultDialog.id
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf ccKimk css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe emeDgd css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
@@ -468,7 +468,7 @@ exports[`Rendering test renders correctly when open with publication disabled 1`
           class="MuiDialogContent-root MuiDialogContent-dividers css-10bxh4q-MuiDialogContent-root"
         >
           <div
-            class="MuiFormControl-root sc-gEvEes HwpMG css-1iw3t7y-MuiFormControl-root"
+            class="MuiFormControl-root sc-gtcBCx hoLdIB css-1iw3t7y-MuiFormControl-root"
           >
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
@@ -478,7 +478,7 @@ exports[`Rendering test renders correctly when open with publication disabled 1`
               saveResultDialog.id
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf ccKimk css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe emeDgd css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"

--- a/PxGraf.Frontend/src/components/SaveResultDialog/__snapshots__/SuccessDialogContent.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/SaveResultDialog/__snapshots__/SuccessDialogContent.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Rendering test renders correctly when closed 1`] = `
     class="MuiDialogContent-root MuiDialogContent-dividers css-10bxh4q-MuiDialogContent-root"
   >
     <div
-      class="MuiFormControl-root sc-gEvEes HwpMG css-1iw3t7y-MuiFormControl-root"
+      class="MuiFormControl-root sc-gtcBCx hoLdIB css-1iw3t7y-MuiFormControl-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
@@ -16,7 +16,7 @@ exports[`Rendering test renders correctly when closed 1`] = `
         Selection identifier
       </label>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf ccKimk css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe emeDgd css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <input
           aria-invalid="false"
@@ -73,7 +73,7 @@ exports[`Rendering test renders correctly when open (draft) 1`] = `
       class="MuiDialogContent-root MuiDialogContent-dividers css-10bxh4q-MuiDialogContent-root"
     >
       <div
-        class="MuiFormControl-root sc-gEvEes HwpMG css-1iw3t7y-MuiFormControl-root"
+        class="MuiFormControl-root sc-gtcBCx hoLdIB css-1iw3t7y-MuiFormControl-root"
       >
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
@@ -83,7 +83,7 @@ exports[`Rendering test renders correctly when open (draft) 1`] = `
           Selection identifier
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf ccKimk css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe emeDgd css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
@@ -141,7 +141,7 @@ exports[`Rendering test renders correctly with webhook success message 1`] = `
       class="MuiDialogContent-root MuiDialogContent-dividers css-10bxh4q-MuiDialogContent-root"
     >
       <div
-        class="MuiFormControl-root sc-gEvEes HwpMG css-1iw3t7y-MuiFormControl-root"
+        class="MuiFormControl-root sc-gtcBCx hoLdIB css-1iw3t7y-MuiFormControl-root"
       >
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
@@ -151,7 +151,7 @@ exports[`Rendering test renders correctly with webhook success message 1`] = `
           Selection identifier
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf ccKimk css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe emeDgd css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
@@ -235,7 +235,7 @@ exports[`Rendering test renders correctly without webhook message (failed) 1`] =
       class="MuiDialogContent-root MuiDialogContent-dividers css-10bxh4q-MuiDialogContent-root"
     >
       <div
-        class="MuiFormControl-root sc-gEvEes HwpMG css-1iw3t7y-MuiFormControl-root"
+        class="MuiFormControl-root sc-gtcBCx hoLdIB css-1iw3t7y-MuiFormControl-root"
       >
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
@@ -245,7 +245,7 @@ exports[`Rendering test renders correctly without webhook message (failed) 1`] =
           Selection identifier
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf ccKimk css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe emeDgd css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
@@ -329,7 +329,7 @@ exports[`Rendering test renders correctly without webhook message (success) 1`] 
       class="MuiDialogContent-root MuiDialogContent-dividers css-10bxh4q-MuiDialogContent-root"
     >
       <div
-        class="MuiFormControl-root sc-gEvEes HwpMG css-1iw3t7y-MuiFormControl-root"
+        class="MuiFormControl-root sc-gtcBCx hoLdIB css-1iw3t7y-MuiFormControl-root"
       >
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
@@ -339,7 +339,7 @@ exports[`Rendering test renders correctly without webhook message (success) 1`] 
           Selection identifier
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-aXZVf ccKimk css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd sc-bdDsCe emeDgd css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"

--- a/PxGraf.Frontend/src/components/TabPanel/__snapshots__/TabPanel.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/TabPanel/__snapshots__/TabPanel.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Rendering test renders correctly with selected value 1`] = `
     role="tabpanel"
   >
     <div
-      class="sc-aXZVf eSKBbS MuiBox-root css-0"
+      class="sc-bdDsCe ewwDVL MuiBox-root css-0"
     >
       foobarbaz
     </div>

--- a/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/__snapshots__/AllDimensionSelection.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/__snapshots__/AllDimensionSelection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-aXZVf OfQRa MuiBox-root css-0"
+    class="sc-bdDsCe jkMRzj MuiBox-root css-0"
   >
     <p
       class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"

--- a/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/__snapshots__/ManualPickDimensionSelection.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/__snapshots__/ManualPickDimensionSelection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-aXZVf bxFDRH css-o5oj2-MuiAutocomplete-root"
+    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-bdDsCe gGPqwe css-o5oj2-MuiAutocomplete-root"
   >
     <div
       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"

--- a/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/__snapshots__/StartingFromDimensionSelection.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/__snapshots__/StartingFromDimensionSelection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-aXZVf jnGhFW css-1tlcqt-MuiAutocomplete-root"
+    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-bdDsCe bjIrin css-1tlcqt-MuiAutocomplete-root"
   >
     <div
       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"

--- a/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/__snapshots__/TopNDimensionSelection.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/VariableSelection/FilterComponents/__snapshots__/TopNDimensionSelection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root sc-aXZVf hYcwSA css-cmpglg-MuiFormControl-root-MuiTextField-root"
+    class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root sc-bdDsCe ljkTCB css-cmpglg-MuiFormControl-root-MuiTextField-root"
   >
     <label
       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"

--- a/PxGraf.Frontend/src/components/VariableSelection/__snapshots__/DefaultSelectableDimensionSelection.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/VariableSelection/__snapshots__/DefaultSelectableDimensionSelection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly with default selectable 1`] = `
 <DocumentFragment>
   <div
-    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-aXZVf lcTUdh css-1tlcqt-MuiAutocomplete-root"
+    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-bdDsCe jqpDuY css-1tlcqt-MuiAutocomplete-root"
   >
     <div
       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -95,7 +95,7 @@ exports[`Rendering test renders correctly with default selectable 1`] = `
 exports[`Rendering test renders correctly without default selectable 1`] = `
 <DocumentFragment>
   <div
-    class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon sc-aXZVf lcTUdh css-1tlcqt-MuiAutocomplete-root"
+    class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon sc-bdDsCe jqpDuY css-1tlcqt-MuiAutocomplete-root"
   >
     <div
       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -168,7 +168,7 @@ exports[`Rendering test renders correctly without default selectable 1`] = `
 exports[`Rendering test renders correctly without resolved dimension value codes 1`] = `
 <DocumentFragment>
   <div
-    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-aXZVf lcTUdh css-1tlcqt-MuiAutocomplete-root"
+    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-bdDsCe jqpDuY css-1tlcqt-MuiAutocomplete-root"
   >
     <div
       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"

--- a/PxGraf.Frontend/src/components/VariableSelection/__snapshots__/DimensionSelection.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/VariableSelection/__snapshots__/DimensionSelection.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiStack-root sc-kpDqfp bBTtYc css-1sazv7p-MuiStack-root"
+    class="MuiStack-root sc-kEbgWM cjPnPc css-1sazv7p-MuiStack-root"
   >
     <div
-      class="MuiStack-root sc-dhKdcy bEdgEi css-m69qwo-MuiStack-root"
+      class="MuiStack-root sc-jrIDTr eeuQxt css-m69qwo-MuiStack-root"
     >
       <span
         aria-label="variableSelect.openMenu"
@@ -28,7 +28,7 @@ exports[`Rendering test renders correctly 1`] = `
         </svg>
       </span>
       <div
-        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root sc-imWYAH fcGBZU css-cmpglg-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root sc-fuztkK fBrzer css-cmpglg-MuiFormControl-root-MuiTextField-root"
       >
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
@@ -66,7 +66,7 @@ exports[`Rendering test renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiStack-root sc-dcJsrX kBjfng css-nen11g-MuiStack-root"
+      class="MuiStack-root sc-eCQgVK ehigaw css-nen11g-MuiStack-root"
     >
       <p
         class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
@@ -74,10 +74,10 @@ exports[`Rendering test renders correctly 1`] = `
         general.results:
       </p>
       <ul
-        class="MuiList-root MuiList-padding MuiList-dense sc-aXZVf gta-dsx css-st2ob2-MuiList-root"
+        class="MuiList-root MuiList-padding MuiList-dense sc-bdDsCe lcgotI css-st2ob2-MuiList-root"
       >
         <li
-          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
         >
           <div
             class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -90,7 +90,7 @@ exports[`Rendering test renders correctly 1`] = `
           </div>
         </li>
         <li
-          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
         >
           <div
             class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -103,7 +103,7 @@ exports[`Rendering test renders correctly 1`] = `
           </div>
         </li>
         <li
-          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
         >
           <div
             class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -116,7 +116,7 @@ exports[`Rendering test renders correctly 1`] = `
           </div>
         </li>
         <li
-          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
         >
           <div
             class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"

--- a/PxGraf.Frontend/src/components/VariableSelection/__snapshots__/DimensionSelectionList.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/VariableSelection/__snapshots__/DimensionSelectionList.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-jEACwF hfpDnV"
+    class="sc-bqqMSY caqzcx"
   >
     <p
       class="MuiTypography-root MuiTypography-body2 css-1wle3ir-MuiTypography-root"
@@ -12,7 +12,7 @@ exports[`Rendering test renders correctly 1`] = `
     </p>
     <button
       aria-label="tooltip.open: variableSelect.title"
-      class="sc-dAlyuI irRRBj"
+      class="sc-iqkkDd dZtsC"
       id="mainContent"
     >
       <svg
@@ -29,7 +29,7 @@ exports[`Rendering test renders correctly 1`] = `
     </button>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-dLMFT bSWlSE css-1808mag-MuiPaper-root-MuiAccordion-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-hCcPtG gjYMFl css-1808mag-MuiPaper-root-MuiAccordion-root"
     style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
   >
     <h3
@@ -86,13 +86,13 @@ exports[`Rendering test renders correctly 1`] = `
             role="region"
           >
             <div
-              class="MuiAccordionDetails-root sc-cPiKLY jYkpdy css-1lj39kh-MuiAccordionDetails-root"
+              class="MuiAccordionDetails-root sc-krVzYl jEIFev css-1lj39kh-MuiAccordionDetails-root"
             >
               <div
-                class="MuiStack-root sc-kpDqfp bBTtYc css-1sazv7p-MuiStack-root"
+                class="MuiStack-root sc-kEbgWM cjPnPc css-1sazv7p-MuiStack-root"
               >
                 <div
-                  class="MuiStack-root sc-dhKdcy bEdgEi css-m69qwo-MuiStack-root"
+                  class="MuiStack-root sc-jrIDTr eeuQxt css-m69qwo-MuiStack-root"
                 >
                   <span
                     aria-label="variableSelect.openMenu"
@@ -114,7 +114,7 @@ exports[`Rendering test renders correctly 1`] = `
                     </svg>
                   </span>
                   <div
-                    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-iGgWBk eZCLgH css-o5oj2-MuiAutocomplete-root"
+                    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-jSppWd iJXiSX css-o5oj2-MuiAutocomplete-root"
                   >
                     <div
                       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -264,7 +264,7 @@ exports[`Rendering test renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-dLMFT bSWlSE css-1808mag-MuiPaper-root-MuiAccordion-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-hCcPtG gjYMFl css-1808mag-MuiPaper-root-MuiAccordion-root"
     style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
   >
     <h3
@@ -321,13 +321,13 @@ exports[`Rendering test renders correctly 1`] = `
             role="region"
           >
             <div
-              class="MuiAccordionDetails-root sc-cPiKLY jYkpdy css-1lj39kh-MuiAccordionDetails-root"
+              class="MuiAccordionDetails-root sc-krVzYl jEIFev css-1lj39kh-MuiAccordionDetails-root"
             >
               <div
-                class="MuiStack-root sc-kpDqfp bBTtYc css-1sazv7p-MuiStack-root"
+                class="MuiStack-root sc-kEbgWM cjPnPc css-1sazv7p-MuiStack-root"
               >
                 <div
-                  class="MuiStack-root sc-dhKdcy bEdgEi css-m69qwo-MuiStack-root"
+                  class="MuiStack-root sc-jrIDTr eeuQxt css-m69qwo-MuiStack-root"
                 >
                   <span
                     aria-label="variableSelect.openMenu"
@@ -349,7 +349,7 @@ exports[`Rendering test renders correctly 1`] = `
                     </svg>
                   </span>
                   <div
-                    class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root sc-imWYAH fcGBZU css-cmpglg-MuiFormControl-root-MuiTextField-root"
+                    class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root sc-fuztkK fBrzer css-cmpglg-MuiFormControl-root-MuiTextField-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
@@ -387,7 +387,7 @@ exports[`Rendering test renders correctly 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiStack-root sc-dcJsrX kBjfng css-nen11g-MuiStack-root"
+                  class="MuiStack-root sc-eCQgVK ehigaw css-nen11g-MuiStack-root"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
@@ -395,10 +395,10 @@ exports[`Rendering test renders correctly 1`] = `
                     general.results:
                   </p>
                   <ul
-                    class="MuiList-root MuiList-padding MuiList-dense sc-aXZVf gta-dsx css-st2ob2-MuiList-root"
+                    class="MuiList-root MuiList-padding MuiList-dense sc-bdDsCe lcgotI css-st2ob2-MuiList-root"
                   >
                     <li
-                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
                     >
                       <div
                         class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -411,7 +411,7 @@ exports[`Rendering test renders correctly 1`] = `
                       </div>
                     </li>
                     <li
-                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
                     >
                       <div
                         class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -424,7 +424,7 @@ exports[`Rendering test renders correctly 1`] = `
                       </div>
                     </li>
                     <li
-                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
                     >
                       <div
                         class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -437,7 +437,7 @@ exports[`Rendering test renders correctly 1`] = `
                       </div>
                     </li>
                     <li
-                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
                     >
                       <div
                         class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -491,7 +491,7 @@ exports[`Rendering test renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-dLMFT bSWlSE css-1808mag-MuiPaper-root-MuiAccordion-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-hCcPtG gjYMFl css-1808mag-MuiPaper-root-MuiAccordion-root"
     style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
   >
     <h3
@@ -548,13 +548,13 @@ exports[`Rendering test renders correctly 1`] = `
             role="region"
           >
             <div
-              class="MuiAccordionDetails-root sc-cPiKLY jYkpdy css-1lj39kh-MuiAccordionDetails-root"
+              class="MuiAccordionDetails-root sc-krVzYl jEIFev css-1lj39kh-MuiAccordionDetails-root"
             >
               <div
-                class="MuiStack-root sc-kpDqfp bBTtYc css-1sazv7p-MuiStack-root"
+                class="MuiStack-root sc-kEbgWM cjPnPc css-1sazv7p-MuiStack-root"
               >
                 <div
-                  class="MuiStack-root sc-dhKdcy bEdgEi css-m69qwo-MuiStack-root"
+                  class="MuiStack-root sc-jrIDTr eeuQxt css-m69qwo-MuiStack-root"
                 >
                   <span
                     aria-label="variableSelect.openMenu"
@@ -576,7 +576,7 @@ exports[`Rendering test renders correctly 1`] = `
                     </svg>
                   </span>
                   <div
-                    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-iGgWBk eZCLgH css-o5oj2-MuiAutocomplete-root"
+                    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-jSppWd iJXiSX css-o5oj2-MuiAutocomplete-root"
                   >
                     <div
                       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -749,7 +749,7 @@ exports[`Rendering test renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-dLMFT bSWlSE css-1808mag-MuiPaper-root-MuiAccordion-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-hCcPtG gjYMFl css-1808mag-MuiPaper-root-MuiAccordion-root"
     style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
   >
     <h3
@@ -806,13 +806,13 @@ exports[`Rendering test renders correctly 1`] = `
             role="region"
           >
             <div
-              class="MuiAccordionDetails-root sc-cPiKLY jYkpdy css-1lj39kh-MuiAccordionDetails-root"
+              class="MuiAccordionDetails-root sc-krVzYl jEIFev css-1lj39kh-MuiAccordionDetails-root"
             >
               <div
-                class="MuiStack-root sc-kpDqfp bBTtYc css-1sazv7p-MuiStack-root"
+                class="MuiStack-root sc-kEbgWM cjPnPc css-1sazv7p-MuiStack-root"
               >
                 <div
-                  class="MuiStack-root sc-dhKdcy bEdgEi css-m69qwo-MuiStack-root"
+                  class="MuiStack-root sc-jrIDTr eeuQxt css-m69qwo-MuiStack-root"
                 >
                   <span
                     aria-label="variableSelect.openMenu"
@@ -834,7 +834,7 @@ exports[`Rendering test renders correctly 1`] = `
                     </svg>
                   </span>
                   <div
-                    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-kAycey cEYeGt css-1tlcqt-MuiAutocomplete-root"
+                    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-iCECmn jICumv css-1tlcqt-MuiAutocomplete-root"
                   >
                     <div
                       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -922,7 +922,7 @@ exports[`Rendering test renders correctly 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiStack-root sc-dcJsrX kBjfng css-nen11g-MuiStack-root"
+                  class="MuiStack-root sc-eCQgVK ehigaw css-nen11g-MuiStack-root"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
@@ -930,10 +930,10 @@ exports[`Rendering test renders correctly 1`] = `
                     general.results:
                   </p>
                   <ul
-                    class="MuiList-root MuiList-padding MuiList-dense sc-aXZVf gta-dsx css-st2ob2-MuiList-root"
+                    class="MuiList-root MuiList-padding MuiList-dense sc-bdDsCe lcgotI css-st2ob2-MuiList-root"
                   >
                     <li
-                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
                     >
                       <div
                         class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -946,7 +946,7 @@ exports[`Rendering test renders correctly 1`] = `
                       </div>
                     </li>
                     <li
-                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
                     >
                       <div
                         class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -959,7 +959,7 @@ exports[`Rendering test renders correctly 1`] = `
                       </div>
                     </li>
                     <li
-                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
                     >
                       <div
                         class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -1013,7 +1013,7 @@ exports[`Rendering test renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-dLMFT bSWlSE css-1808mag-MuiPaper-root-MuiAccordion-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-hCcPtG gjYMFl css-1808mag-MuiPaper-root-MuiAccordion-root"
     style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
   >
     <h3
@@ -1070,13 +1070,13 @@ exports[`Rendering test renders correctly 1`] = `
             role="region"
           >
             <div
-              class="MuiAccordionDetails-root sc-cPiKLY jYkpdy css-1lj39kh-MuiAccordionDetails-root"
+              class="MuiAccordionDetails-root sc-krVzYl jEIFev css-1lj39kh-MuiAccordionDetails-root"
             >
               <div
-                class="MuiStack-root sc-kpDqfp bBTtYc css-1sazv7p-MuiStack-root"
+                class="MuiStack-root sc-kEbgWM cjPnPc css-1sazv7p-MuiStack-root"
               >
                 <div
-                  class="MuiStack-root sc-dhKdcy bEdgEi css-m69qwo-MuiStack-root"
+                  class="MuiStack-root sc-jrIDTr eeuQxt css-m69qwo-MuiStack-root"
                 >
                   <span
                     aria-label="variableSelect.openMenu"
@@ -1098,7 +1098,7 @@ exports[`Rendering test renders correctly 1`] = `
                     </svg>
                   </span>
                   <div
-                    class="sc-gsFSXt iOsDE MuiBox-root css-0"
+                    class="sc-gKkgUA gfREpc MuiBox-root css-0"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
@@ -1108,7 +1108,7 @@ exports[`Rendering test renders correctly 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiStack-root sc-dcJsrX kBjfng css-nen11g-MuiStack-root"
+                  class="MuiStack-root sc-eCQgVK ehigaw css-nen11g-MuiStack-root"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
@@ -1116,10 +1116,10 @@ exports[`Rendering test renders correctly 1`] = `
                     general.results:
                   </p>
                   <ul
-                    class="MuiList-root MuiList-padding MuiList-dense sc-aXZVf gta-dsx css-st2ob2-MuiList-root"
+                    class="MuiList-root MuiList-padding MuiList-dense sc-bdDsCe lcgotI css-st2ob2-MuiList-root"
                   >
                     <li
-                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
                     >
                       <div
                         class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -1132,7 +1132,7 @@ exports[`Rendering test renders correctly 1`] = `
                       </div>
                     </li>
                     <li
-                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
                     >
                       <div
                         class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -1145,7 +1145,7 @@ exports[`Rendering test renders correctly 1`] = `
                       </div>
                     </li>
                     <li
-                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+                      class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
                     >
                       <div
                         class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -1199,7 +1199,7 @@ exports[`Rendering test renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-dLMFT bSWlSE css-1808mag-MuiPaper-root-MuiAccordion-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-hCcPtG gjYMFl css-1808mag-MuiPaper-root-MuiAccordion-root"
     style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
   >
     <h3
@@ -1256,13 +1256,13 @@ exports[`Rendering test renders correctly 1`] = `
             role="region"
           >
             <div
-              class="MuiAccordionDetails-root sc-cPiKLY jYkpdy css-1lj39kh-MuiAccordionDetails-root"
+              class="MuiAccordionDetails-root sc-krVzYl jEIFev css-1lj39kh-MuiAccordionDetails-root"
             >
               <div
-                class="MuiStack-root sc-kpDqfp bBTtYc css-1sazv7p-MuiStack-root"
+                class="MuiStack-root sc-kEbgWM cjPnPc css-1sazv7p-MuiStack-root"
               >
                 <div
-                  class="MuiStack-root sc-dhKdcy bEdgEi css-m69qwo-MuiStack-root"
+                  class="MuiStack-root sc-jrIDTr eeuQxt css-m69qwo-MuiStack-root"
                 >
                   <span
                     aria-label="variableSelect.openMenu"
@@ -1284,7 +1284,7 @@ exports[`Rendering test renders correctly 1`] = `
                     </svg>
                   </span>
                   <div
-                    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-iGgWBk eZCLgH css-o5oj2-MuiAutocomplete-root"
+                    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-jSppWd iJXiSX css-o5oj2-MuiAutocomplete-root"
                   >
                     <div
                       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -1434,7 +1434,7 @@ exports[`Rendering test renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-dLMFT bSWlSE css-1808mag-MuiPaper-root-MuiAccordion-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-hCcPtG gjYMFl css-1808mag-MuiPaper-root-MuiAccordion-root"
     style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
   >
     <h3
@@ -1491,13 +1491,13 @@ exports[`Rendering test renders correctly 1`] = `
             role="region"
           >
             <div
-              class="MuiAccordionDetails-root sc-cPiKLY jYkpdy css-1lj39kh-MuiAccordionDetails-root"
+              class="MuiAccordionDetails-root sc-krVzYl jEIFev css-1lj39kh-MuiAccordionDetails-root"
             >
               <div
-                class="MuiStack-root sc-kpDqfp bBTtYc css-1sazv7p-MuiStack-root"
+                class="MuiStack-root sc-kEbgWM cjPnPc css-1sazv7p-MuiStack-root"
               >
                 <div
-                  class="MuiStack-root sc-dhKdcy bEdgEi css-m69qwo-MuiStack-root"
+                  class="MuiStack-root sc-jrIDTr eeuQxt css-m69qwo-MuiStack-root"
                 >
                   <span
                     aria-label="variableSelect.openMenu"
@@ -1519,7 +1519,7 @@ exports[`Rendering test renders correctly 1`] = `
                     </svg>
                   </span>
                   <div
-                    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-iGgWBk eZCLgH css-o5oj2-MuiAutocomplete-root"
+                    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-jSppWd iJXiSX css-o5oj2-MuiAutocomplete-root"
                   >
                     <div
                       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -1669,7 +1669,7 @@ exports[`Rendering test renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-dLMFT bSWlSE css-1808mag-MuiPaper-root-MuiAccordion-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-hCcPtG gjYMFl css-1808mag-MuiPaper-root-MuiAccordion-root"
     style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
   >
     <h3
@@ -1726,13 +1726,13 @@ exports[`Rendering test renders correctly 1`] = `
             role="region"
           >
             <div
-              class="MuiAccordionDetails-root sc-cPiKLY jYkpdy css-1lj39kh-MuiAccordionDetails-root"
+              class="MuiAccordionDetails-root sc-krVzYl jEIFev css-1lj39kh-MuiAccordionDetails-root"
             >
               <div
-                class="MuiStack-root sc-kpDqfp bBTtYc css-1sazv7p-MuiStack-root"
+                class="MuiStack-root sc-kEbgWM cjPnPc css-1sazv7p-MuiStack-root"
               >
                 <div
-                  class="MuiStack-root sc-dhKdcy bEdgEi css-m69qwo-MuiStack-root"
+                  class="MuiStack-root sc-jrIDTr eeuQxt css-m69qwo-MuiStack-root"
                 >
                   <span
                     aria-label="variableSelect.openMenu"
@@ -1754,7 +1754,7 @@ exports[`Rendering test renders correctly 1`] = `
                     </svg>
                   </span>
                   <div
-                    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-iGgWBk eZCLgH css-o5oj2-MuiAutocomplete-root"
+                    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon sc-jSppWd iJXiSX css-o5oj2-MuiAutocomplete-root"
                   >
                     <div
                       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"

--- a/PxGraf.Frontend/src/components/VariableSelection/__snapshots__/ResultList.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/VariableSelection/__snapshots__/ResultList.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiStack-root sc-dcJsrX kBjfng css-nen11g-MuiStack-root"
+    class="MuiStack-root sc-eCQgVK ehigaw css-nen11g-MuiStack-root"
   >
     <p
       class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
@@ -11,10 +11,10 @@ exports[`Rendering test renders correctly 1`] = `
       general.results:
     </p>
     <ul
-      class="MuiList-root MuiList-padding MuiList-dense sc-aXZVf gta-dsx css-st2ob2-MuiList-root"
+      class="MuiList-root MuiList-padding MuiList-dense sc-bdDsCe lcgotI css-st2ob2-MuiList-root"
     >
       <li
-        class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+        class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
       >
         <div
           class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -27,7 +27,7 @@ exports[`Rendering test renders correctly 1`] = `
         </div>
       </li>
       <li
-        class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+        class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
       >
         <div
           class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/__snapshots__/TablePivotSettings.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/TypeSpecificControls/__snapshots__/TablePivotSettings.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`Rendering test renders correctly 1`] = `
     class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
   >
     <div
-      class="MuiStack-root sc-gEvEes DXrrR css-m69qwo-MuiStack-root"
+      class="MuiStack-root sc-gtcBCx dCkIcm css-m69qwo-MuiStack-root"
     >
       <ul
-        class="MuiList-root MuiList-padding MuiList-dense MuiList-subheader sc-aXZVf gUgMaW css-h1es49-MuiList-root"
+        class="MuiList-root MuiList-padding MuiList-dense MuiList-subheader sc-bdDsCe dYIBqr css-h1es49-MuiList-root"
       >
         <li
           class="MuiListSubheader-root MuiListSubheader-gutters MuiListSubheader-sticky css-l328gy-MuiListSubheader-root"
@@ -48,7 +48,7 @@ exports[`Rendering test renders correctly 1`] = `
         </div>
       </ul>
       <div
-        class="MuiStack-root sc-eqUAAB datwPa css-nen11g-MuiStack-root"
+        class="MuiStack-root sc-dkXsAU jLBdQA css-nen11g-MuiStack-root"
       >
         <button
           aria-label="tableSettings.up"
@@ -106,7 +106,7 @@ exports[`Rendering test renders correctly 1`] = `
         </button>
       </div>
       <ul
-        class="MuiList-root MuiList-padding MuiList-dense MuiList-subheader sc-aXZVf gUgMaW css-h1es49-MuiList-root"
+        class="MuiList-root MuiList-padding MuiList-dense MuiList-subheader sc-bdDsCe dYIBqr css-h1es49-MuiList-root"
       >
         <li
           class="MuiListSubheader-root MuiListSubheader-gutters MuiListSubheader-sticky css-l328gy-MuiListSubheader-root"

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/__snapshots__/MarkerScaler.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/__snapshots__/MarkerScaler.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiStack-root sc-aXZVf iTkpDF css-m69qwo-MuiStack-root"
+    class="MuiStack-root sc-bdDsCe jGbDaY css-m69qwo-MuiStack-root"
   >
     <div
       class="MuiBox-root css-0"
@@ -15,7 +15,7 @@ exports[`Rendering test renders correctly 1`] = `
         chartSettings.markerScale
       </p>
       <span
-        class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-gEvEes vPJEP css-1e45yg4-MuiSlider-root"
+        class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-gtcBCx cxWVgc css-1e45yg4-MuiSlider-root"
       >
         <span
           class="MuiSlider-rail css-r64h58-MuiSlider-rail"

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/__snapshots__/VisualizationSettingsSwitch.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/UtilityComponents/__snapshots__/VisualizationSettingsSwitch.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`Rendering test renders correctly 1`] = `
         class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
       >
         <p
-          class="MuiTypography-root MuiTypography-body1 sc-gEvEes eXvEWk css-rizt0-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 sc-gtcBCx iIKXAz css-rizt0-MuiTypography-root"
         >
           label
         </p>

--- a/PxGraf.Frontend/src/components/VisualizationSettingsControls/__snapshots__/VisualizationSettingsControl.test.tsx.snap
+++ b/PxGraf.Frontend/src/components/VisualizationSettingsControls/__snapshots__/VisualizationSettingsControl.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Rendering test renders grouphorizontalbarchart correctly 1`] = `
   <div>
     <button
       aria-label="tooltip.open: tooltip.visualizationConfig"
-      class="sc-iGgWBk fpTGjA"
+      class="sc-jSppWd bRaFSg"
     >
       <svg
         aria-hidden="true"
@@ -20,10 +20,10 @@ exports[`Rendering test renders grouphorizontalbarchart correctly 1`] = `
       </svg>
     </button>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
-        class="MuiStack-root sc-fqkvVO jBIpXp css-m69qwo-MuiStack-root"
+        class="MuiStack-root sc-hKVpXn kRlmhA css-m69qwo-MuiStack-root"
       >
         <div
           class="MuiBox-root css-0"
@@ -35,7 +35,7 @@ exports[`Rendering test renders grouphorizontalbarchart correctly 1`] = `
             chartSettings.markerScale
           </p>
           <span
-            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-dcJsrX bEYKHo css-1e45yg4-MuiSlider-root"
+            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-eCQgVK iIlfgg css-1e45yg4-MuiSlider-root"
           >
             <span
               class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -122,7 +122,7 @@ exports[`Rendering test renders grouphorizontalbarchart correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
         class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
@@ -153,7 +153,7 @@ exports[`Rendering test renders grouphorizontalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.cutYAxis
             </p>
@@ -161,7 +161,7 @@ exports[`Rendering test renders grouphorizontalbarchart correctly 1`] = `
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiFormControl-fullWidth sc-imWYAH homFhm css-ytlejw-MuiFormControl-root"
+        class="MuiFormControl-root MuiFormControl-fullWidth sc-fuztkK cZbnHF css-ytlejw-MuiFormControl-root"
       >
         <label
           class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
@@ -189,7 +189,7 @@ exports[`Rendering test renders grouphorizontalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.matchXLabelsToEnd
             </p>
@@ -225,7 +225,7 @@ exports[`Rendering test renders grouphorizontalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               visualizationSettings.showDataPoints
             </p>
@@ -242,7 +242,7 @@ exports[`Rendering test renders groupverticalbarchart correctly 1`] = `
   <div>
     <button
       aria-label="tooltip.open: tooltip.visualizationConfig"
-      class="sc-iGgWBk fpTGjA"
+      class="sc-jSppWd bRaFSg"
     >
       <svg
         aria-hidden="true"
@@ -257,10 +257,10 @@ exports[`Rendering test renders groupverticalbarchart correctly 1`] = `
       </svg>
     </button>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
-        class="MuiStack-root sc-fqkvVO jBIpXp css-m69qwo-MuiStack-root"
+        class="MuiStack-root sc-hKVpXn kRlmhA css-m69qwo-MuiStack-root"
       >
         <div
           class="MuiBox-root css-0"
@@ -272,7 +272,7 @@ exports[`Rendering test renders groupverticalbarchart correctly 1`] = `
             chartSettings.markerScale
           </p>
           <span
-            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-dcJsrX bEYKHo css-1e45yg4-MuiSlider-root"
+            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-eCQgVK iIlfgg css-1e45yg4-MuiSlider-root"
           >
             <span
               class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -359,7 +359,7 @@ exports[`Rendering test renders groupverticalbarchart correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
         class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
@@ -390,7 +390,7 @@ exports[`Rendering test renders groupverticalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.cutYAxis
             </p>
@@ -398,7 +398,7 @@ exports[`Rendering test renders groupverticalbarchart correctly 1`] = `
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiFormControl-fullWidth sc-imWYAH homFhm css-ytlejw-MuiFormControl-root"
+        class="MuiFormControl-root MuiFormControl-fullWidth sc-fuztkK cZbnHF css-ytlejw-MuiFormControl-root"
       >
         <label
           class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
@@ -426,7 +426,7 @@ exports[`Rendering test renders groupverticalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.matchXLabelsToEnd
             </p>
@@ -462,7 +462,7 @@ exports[`Rendering test renders groupverticalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               visualizationSettings.showDataPoints
             </p>
@@ -479,7 +479,7 @@ exports[`Rendering test renders horizontalbarchart correctly 1`] = `
   <div>
     <button
       aria-label="tooltip.open: tooltip.visualizationConfig"
-      class="sc-iGgWBk fpTGjA"
+      class="sc-jSppWd bRaFSg"
     >
       <svg
         aria-hidden="true"
@@ -494,10 +494,10 @@ exports[`Rendering test renders horizontalbarchart correctly 1`] = `
       </svg>
     </button>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
-        class="MuiStack-root sc-fqkvVO jBIpXp css-m69qwo-MuiStack-root"
+        class="MuiStack-root sc-hKVpXn kRlmhA css-m69qwo-MuiStack-root"
       >
         <div
           class="MuiBox-root css-0"
@@ -509,7 +509,7 @@ exports[`Rendering test renders horizontalbarchart correctly 1`] = `
             chartSettings.markerScale
           </p>
           <span
-            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-dcJsrX bEYKHo css-1e45yg4-MuiSlider-root"
+            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-eCQgVK iIlfgg css-1e45yg4-MuiSlider-root"
           >
             <span
               class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -596,7 +596,7 @@ exports[`Rendering test renders horizontalbarchart correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
         class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
@@ -627,7 +627,7 @@ exports[`Rendering test renders horizontalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.cutYAxis
             </p>
@@ -635,7 +635,7 @@ exports[`Rendering test renders horizontalbarchart correctly 1`] = `
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiFormControl-fullWidth sc-imWYAH homFhm css-ytlejw-MuiFormControl-root"
+        class="MuiFormControl-root MuiFormControl-fullWidth sc-fuztkK cZbnHF css-ytlejw-MuiFormControl-root"
       >
         <label
           class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
@@ -663,7 +663,7 @@ exports[`Rendering test renders horizontalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.matchXLabelsToEnd
             </p>
@@ -699,7 +699,7 @@ exports[`Rendering test renders horizontalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               visualizationSettings.showDataPoints
             </p>
@@ -716,7 +716,7 @@ exports[`Rendering test renders linechart correctly 1`] = `
   <div>
     <button
       aria-label="tooltip.open: tooltip.visualizationConfig"
-      class="sc-iGgWBk fpTGjA"
+      class="sc-jSppWd bRaFSg"
     >
       <svg
         aria-hidden="true"
@@ -731,10 +731,10 @@ exports[`Rendering test renders linechart correctly 1`] = `
       </svg>
     </button>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
-        class="MuiStack-root sc-fqkvVO jBIpXp css-m69qwo-MuiStack-root"
+        class="MuiStack-root sc-hKVpXn kRlmhA css-m69qwo-MuiStack-root"
       >
         <div
           class="MuiBox-root css-0"
@@ -746,7 +746,7 @@ exports[`Rendering test renders linechart correctly 1`] = `
             chartSettings.markerScale
           </p>
           <span
-            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-dcJsrX bEYKHo css-1e45yg4-MuiSlider-root"
+            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-eCQgVK iIlfgg css-1e45yg4-MuiSlider-root"
           >
             <span
               class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -833,7 +833,7 @@ exports[`Rendering test renders linechart correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
         class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
@@ -864,7 +864,7 @@ exports[`Rendering test renders linechart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.cutYAxis
             </p>
@@ -872,7 +872,7 @@ exports[`Rendering test renders linechart correctly 1`] = `
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiFormControl-fullWidth sc-imWYAH homFhm css-ytlejw-MuiFormControl-root"
+        class="MuiFormControl-root MuiFormControl-fullWidth sc-fuztkK cZbnHF css-ytlejw-MuiFormControl-root"
       >
         <label
           class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
@@ -900,7 +900,7 @@ exports[`Rendering test renders linechart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.matchXLabelsToEnd
             </p>
@@ -936,7 +936,7 @@ exports[`Rendering test renders linechart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               visualizationSettings.showDataPoints
             </p>
@@ -953,7 +953,7 @@ exports[`Rendering test renders percenthorizontalbarchart correctly 1`] = `
   <div>
     <button
       aria-label="tooltip.open: tooltip.visualizationConfig"
-      class="sc-iGgWBk fpTGjA"
+      class="sc-jSppWd bRaFSg"
     >
       <svg
         aria-hidden="true"
@@ -968,10 +968,10 @@ exports[`Rendering test renders percenthorizontalbarchart correctly 1`] = `
       </svg>
     </button>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
-        class="MuiStack-root sc-fqkvVO jBIpXp css-m69qwo-MuiStack-root"
+        class="MuiStack-root sc-hKVpXn kRlmhA css-m69qwo-MuiStack-root"
       >
         <div
           class="MuiBox-root css-0"
@@ -983,7 +983,7 @@ exports[`Rendering test renders percenthorizontalbarchart correctly 1`] = `
             chartSettings.markerScale
           </p>
           <span
-            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-dcJsrX bEYKHo css-1e45yg4-MuiSlider-root"
+            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-eCQgVK iIlfgg css-1e45yg4-MuiSlider-root"
           >
             <span
               class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -1070,7 +1070,7 @@ exports[`Rendering test renders percenthorizontalbarchart correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
         class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
@@ -1101,7 +1101,7 @@ exports[`Rendering test renders percenthorizontalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.cutYAxis
             </p>
@@ -1109,7 +1109,7 @@ exports[`Rendering test renders percenthorizontalbarchart correctly 1`] = `
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiFormControl-fullWidth sc-imWYAH homFhm css-ytlejw-MuiFormControl-root"
+        class="MuiFormControl-root MuiFormControl-fullWidth sc-fuztkK cZbnHF css-ytlejw-MuiFormControl-root"
       >
         <label
           class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
@@ -1137,7 +1137,7 @@ exports[`Rendering test renders percenthorizontalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.matchXLabelsToEnd
             </p>
@@ -1173,7 +1173,7 @@ exports[`Rendering test renders percenthorizontalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               visualizationSettings.showDataPoints
             </p>
@@ -1190,7 +1190,7 @@ exports[`Rendering test renders percentverticalbarchart correctly 1`] = `
   <div>
     <button
       aria-label="tooltip.open: tooltip.visualizationConfig"
-      class="sc-iGgWBk fpTGjA"
+      class="sc-jSppWd bRaFSg"
     >
       <svg
         aria-hidden="true"
@@ -1205,10 +1205,10 @@ exports[`Rendering test renders percentverticalbarchart correctly 1`] = `
       </svg>
     </button>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
-        class="MuiStack-root sc-fqkvVO jBIpXp css-m69qwo-MuiStack-root"
+        class="MuiStack-root sc-hKVpXn kRlmhA css-m69qwo-MuiStack-root"
       >
         <div
           class="MuiBox-root css-0"
@@ -1220,7 +1220,7 @@ exports[`Rendering test renders percentverticalbarchart correctly 1`] = `
             chartSettings.markerScale
           </p>
           <span
-            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-dcJsrX bEYKHo css-1e45yg4-MuiSlider-root"
+            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-eCQgVK iIlfgg css-1e45yg4-MuiSlider-root"
           >
             <span
               class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -1307,7 +1307,7 @@ exports[`Rendering test renders percentverticalbarchart correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
         class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
@@ -1338,7 +1338,7 @@ exports[`Rendering test renders percentverticalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.cutYAxis
             </p>
@@ -1346,7 +1346,7 @@ exports[`Rendering test renders percentverticalbarchart correctly 1`] = `
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiFormControl-fullWidth sc-imWYAH homFhm css-ytlejw-MuiFormControl-root"
+        class="MuiFormControl-root MuiFormControl-fullWidth sc-fuztkK cZbnHF css-ytlejw-MuiFormControl-root"
       >
         <label
           class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
@@ -1374,7 +1374,7 @@ exports[`Rendering test renders percentverticalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.matchXLabelsToEnd
             </p>
@@ -1410,7 +1410,7 @@ exports[`Rendering test renders percentverticalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               visualizationSettings.showDataPoints
             </p>
@@ -1427,7 +1427,7 @@ exports[`Rendering test renders piechart correctly 1`] = `
   <div>
     <button
       aria-label="tooltip.open: tooltip.visualizationConfig"
-      class="sc-iGgWBk fpTGjA"
+      class="sc-jSppWd bRaFSg"
     >
       <svg
         aria-hidden="true"
@@ -1442,10 +1442,10 @@ exports[`Rendering test renders piechart correctly 1`] = `
       </svg>
     </button>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
-        class="MuiStack-root sc-fqkvVO jBIpXp css-m69qwo-MuiStack-root"
+        class="MuiStack-root sc-hKVpXn kRlmhA css-m69qwo-MuiStack-root"
       >
         <div
           class="MuiBox-root css-0"
@@ -1457,7 +1457,7 @@ exports[`Rendering test renders piechart correctly 1`] = `
             chartSettings.markerScale
           </p>
           <span
-            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-dcJsrX bEYKHo css-1e45yg4-MuiSlider-root"
+            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-eCQgVK iIlfgg css-1e45yg4-MuiSlider-root"
           >
             <span
               class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -1544,7 +1544,7 @@ exports[`Rendering test renders piechart correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
         class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
@@ -1575,7 +1575,7 @@ exports[`Rendering test renders piechart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.cutYAxis
             </p>
@@ -1583,7 +1583,7 @@ exports[`Rendering test renders piechart correctly 1`] = `
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiFormControl-fullWidth sc-imWYAH homFhm css-ytlejw-MuiFormControl-root"
+        class="MuiFormControl-root MuiFormControl-fullWidth sc-fuztkK cZbnHF css-ytlejw-MuiFormControl-root"
       >
         <label
           class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
@@ -1611,7 +1611,7 @@ exports[`Rendering test renders piechart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.matchXLabelsToEnd
             </p>
@@ -1647,7 +1647,7 @@ exports[`Rendering test renders piechart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               visualizationSettings.showDataPoints
             </p>
@@ -1664,7 +1664,7 @@ exports[`Rendering test renders scatterplot correctly 1`] = `
   <div>
     <button
       aria-label="tooltip.open: tooltip.visualizationConfig"
-      class="sc-iGgWBk fpTGjA"
+      class="sc-jSppWd bRaFSg"
     >
       <svg
         aria-hidden="true"
@@ -1679,10 +1679,10 @@ exports[`Rendering test renders scatterplot correctly 1`] = `
       </svg>
     </button>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
-        class="MuiStack-root sc-fqkvVO jBIpXp css-m69qwo-MuiStack-root"
+        class="MuiStack-root sc-hKVpXn kRlmhA css-m69qwo-MuiStack-root"
       >
         <div
           class="MuiBox-root css-0"
@@ -1694,7 +1694,7 @@ exports[`Rendering test renders scatterplot correctly 1`] = `
             chartSettings.markerScale
           </p>
           <span
-            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-dcJsrX bEYKHo css-1e45yg4-MuiSlider-root"
+            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-eCQgVK iIlfgg css-1e45yg4-MuiSlider-root"
           >
             <span
               class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -1781,7 +1781,7 @@ exports[`Rendering test renders scatterplot correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
         class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
@@ -1812,7 +1812,7 @@ exports[`Rendering test renders scatterplot correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.cutYAxis
             </p>
@@ -1820,7 +1820,7 @@ exports[`Rendering test renders scatterplot correctly 1`] = `
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiFormControl-fullWidth sc-imWYAH homFhm css-ytlejw-MuiFormControl-root"
+        class="MuiFormControl-root MuiFormControl-fullWidth sc-fuztkK cZbnHF css-ytlejw-MuiFormControl-root"
       >
         <label
           class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
@@ -1848,7 +1848,7 @@ exports[`Rendering test renders scatterplot correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.matchXLabelsToEnd
             </p>
@@ -1884,7 +1884,7 @@ exports[`Rendering test renders scatterplot correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               visualizationSettings.showDataPoints
             </p>
@@ -1901,7 +1901,7 @@ exports[`Rendering test renders stackedhorizontalbarchart correctly 1`] = `
   <div>
     <button
       aria-label="tooltip.open: tooltip.visualizationConfig"
-      class="sc-iGgWBk fpTGjA"
+      class="sc-jSppWd bRaFSg"
     >
       <svg
         aria-hidden="true"
@@ -1916,10 +1916,10 @@ exports[`Rendering test renders stackedhorizontalbarchart correctly 1`] = `
       </svg>
     </button>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
-        class="MuiStack-root sc-fqkvVO jBIpXp css-m69qwo-MuiStack-root"
+        class="MuiStack-root sc-hKVpXn kRlmhA css-m69qwo-MuiStack-root"
       >
         <div
           class="MuiBox-root css-0"
@@ -1931,7 +1931,7 @@ exports[`Rendering test renders stackedhorizontalbarchart correctly 1`] = `
             chartSettings.markerScale
           </p>
           <span
-            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-dcJsrX bEYKHo css-1e45yg4-MuiSlider-root"
+            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-eCQgVK iIlfgg css-1e45yg4-MuiSlider-root"
           >
             <span
               class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -2018,7 +2018,7 @@ exports[`Rendering test renders stackedhorizontalbarchart correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
         class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
@@ -2049,7 +2049,7 @@ exports[`Rendering test renders stackedhorizontalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.cutYAxis
             </p>
@@ -2057,7 +2057,7 @@ exports[`Rendering test renders stackedhorizontalbarchart correctly 1`] = `
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiFormControl-fullWidth sc-imWYAH homFhm css-ytlejw-MuiFormControl-root"
+        class="MuiFormControl-root MuiFormControl-fullWidth sc-fuztkK cZbnHF css-ytlejw-MuiFormControl-root"
       >
         <label
           class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
@@ -2085,7 +2085,7 @@ exports[`Rendering test renders stackedhorizontalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.matchXLabelsToEnd
             </p>
@@ -2121,7 +2121,7 @@ exports[`Rendering test renders stackedhorizontalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               visualizationSettings.showDataPoints
             </p>
@@ -2138,7 +2138,7 @@ exports[`Rendering test renders stackedverticalbarchart correctly 1`] = `
   <div>
     <button
       aria-label="tooltip.open: tooltip.visualizationConfig"
-      class="sc-iGgWBk fpTGjA"
+      class="sc-jSppWd bRaFSg"
     >
       <svg
         aria-hidden="true"
@@ -2153,10 +2153,10 @@ exports[`Rendering test renders stackedverticalbarchart correctly 1`] = `
       </svg>
     </button>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
-        class="MuiStack-root sc-fqkvVO jBIpXp css-m69qwo-MuiStack-root"
+        class="MuiStack-root sc-hKVpXn kRlmhA css-m69qwo-MuiStack-root"
       >
         <div
           class="MuiBox-root css-0"
@@ -2168,7 +2168,7 @@ exports[`Rendering test renders stackedverticalbarchart correctly 1`] = `
             chartSettings.markerScale
           </p>
           <span
-            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-dcJsrX bEYKHo css-1e45yg4-MuiSlider-root"
+            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-eCQgVK iIlfgg css-1e45yg4-MuiSlider-root"
           >
             <span
               class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -2255,7 +2255,7 @@ exports[`Rendering test renders stackedverticalbarchart correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
         class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
@@ -2286,7 +2286,7 @@ exports[`Rendering test renders stackedverticalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.cutYAxis
             </p>
@@ -2294,7 +2294,7 @@ exports[`Rendering test renders stackedverticalbarchart correctly 1`] = `
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiFormControl-fullWidth sc-imWYAH homFhm css-ytlejw-MuiFormControl-root"
+        class="MuiFormControl-root MuiFormControl-fullWidth sc-fuztkK cZbnHF css-ytlejw-MuiFormControl-root"
       >
         <label
           class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
@@ -2322,7 +2322,7 @@ exports[`Rendering test renders stackedverticalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.matchXLabelsToEnd
             </p>
@@ -2358,7 +2358,7 @@ exports[`Rendering test renders stackedverticalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               visualizationSettings.showDataPoints
             </p>
@@ -2375,7 +2375,7 @@ exports[`Rendering test renders table correctly 1`] = `
   <div>
     <button
       aria-label="tooltip.open: tooltip.visualizationConfig"
-      class="sc-iGgWBk fpTGjA"
+      class="sc-jSppWd bRaFSg"
     >
       <svg
         aria-hidden="true"
@@ -2390,16 +2390,16 @@ exports[`Rendering test renders table correctly 1`] = `
       </svg>
     </button>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
         class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
       >
         <div
-          class="MuiStack-root sc-gEvEes DXrrR css-m69qwo-MuiStack-root"
+          class="MuiStack-root sc-gtcBCx dCkIcm css-m69qwo-MuiStack-root"
         >
           <ul
-            class="MuiList-root MuiList-padding MuiList-dense MuiList-subheader sc-aXZVf gUgMaW css-h1es49-MuiList-root"
+            class="MuiList-root MuiList-padding MuiList-dense MuiList-subheader sc-bdDsCe dYIBqr css-h1es49-MuiList-root"
           >
             <li
               class="MuiListSubheader-root MuiListSubheader-gutters MuiListSubheader-sticky css-l328gy-MuiListSubheader-root"
@@ -2438,7 +2438,7 @@ exports[`Rendering test renders table correctly 1`] = `
             </div>
           </ul>
           <div
-            class="MuiStack-root sc-eqUAAB datwPa css-nen11g-MuiStack-root"
+            class="MuiStack-root sc-dkXsAU jLBdQA css-nen11g-MuiStack-root"
           >
             <button
               aria-label="tableSettings.up"
@@ -2496,7 +2496,7 @@ exports[`Rendering test renders table correctly 1`] = `
             </button>
           </div>
           <ul
-            class="MuiList-root MuiList-padding MuiList-dense MuiList-subheader sc-aXZVf gUgMaW css-h1es49-MuiList-root"
+            class="MuiList-root MuiList-padding MuiList-dense MuiList-subheader sc-bdDsCe dYIBqr css-h1es49-MuiList-root"
           >
             <li
               class="MuiListSubheader-root MuiListSubheader-gutters MuiListSubheader-sticky css-l328gy-MuiListSubheader-root"
@@ -2537,7 +2537,7 @@ exports[`Rendering test renders table correctly 1`] = `
         </div>
       </div>
       <div
-        class="MuiStack-root sc-fqkvVO jBIpXp css-m69qwo-MuiStack-root"
+        class="MuiStack-root sc-hKVpXn kRlmhA css-m69qwo-MuiStack-root"
       >
         <div
           class="MuiBox-root css-0"
@@ -2549,7 +2549,7 @@ exports[`Rendering test renders table correctly 1`] = `
             chartSettings.markerScale
           </p>
           <span
-            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-dcJsrX bEYKHo css-1e45yg4-MuiSlider-root"
+            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-eCQgVK iIlfgg css-1e45yg4-MuiSlider-root"
           >
             <span
               class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -2636,7 +2636,7 @@ exports[`Rendering test renders table correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
         class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
@@ -2667,7 +2667,7 @@ exports[`Rendering test renders table correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.cutYAxis
             </p>
@@ -2675,7 +2675,7 @@ exports[`Rendering test renders table correctly 1`] = `
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiFormControl-fullWidth sc-imWYAH homFhm css-ytlejw-MuiFormControl-root"
+        class="MuiFormControl-root MuiFormControl-fullWidth sc-fuztkK cZbnHF css-ytlejw-MuiFormControl-root"
       >
         <label
           class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
@@ -2703,7 +2703,7 @@ exports[`Rendering test renders table correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.matchXLabelsToEnd
             </p>
@@ -2739,7 +2739,7 @@ exports[`Rendering test renders table correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               visualizationSettings.showDataPoints
             </p>
@@ -2756,7 +2756,7 @@ exports[`Rendering test renders verticalbarchart correctly 1`] = `
   <div>
     <button
       aria-label="tooltip.open: tooltip.visualizationConfig"
-      class="sc-iGgWBk fpTGjA"
+      class="sc-jSppWd bRaFSg"
     >
       <svg
         aria-hidden="true"
@@ -2771,10 +2771,10 @@ exports[`Rendering test renders verticalbarchart correctly 1`] = `
       </svg>
     </button>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
-        class="MuiStack-root sc-fqkvVO jBIpXp css-m69qwo-MuiStack-root"
+        class="MuiStack-root sc-hKVpXn kRlmhA css-m69qwo-MuiStack-root"
       >
         <div
           class="MuiBox-root css-0"
@@ -2786,7 +2786,7 @@ exports[`Rendering test renders verticalbarchart correctly 1`] = `
             chartSettings.markerScale
           </p>
           <span
-            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-dcJsrX bEYKHo css-1e45yg4-MuiSlider-root"
+            class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-eCQgVK iIlfgg css-1e45yg4-MuiSlider-root"
           >
             <span
               class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -2873,7 +2873,7 @@ exports[`Rendering test renders verticalbarchart correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-dhKdcy Mpku"
+      class="sc-jrIDTr btfmyZ"
     >
       <div
         class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
@@ -2904,7 +2904,7 @@ exports[`Rendering test renders verticalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.cutYAxis
             </p>
@@ -2912,7 +2912,7 @@ exports[`Rendering test renders verticalbarchart correctly 1`] = `
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiFormControl-fullWidth sc-imWYAH homFhm css-ytlejw-MuiFormControl-root"
+        class="MuiFormControl-root MuiFormControl-fullWidth sc-fuztkK cZbnHF css-ytlejw-MuiFormControl-root"
       >
         <label
           class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
@@ -2940,7 +2940,7 @@ exports[`Rendering test renders verticalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               chartSettings.matchXLabelsToEnd
             </p>
@@ -2976,7 +2976,7 @@ exports[`Rendering test renders verticalbarchart correctly 1`] = `
             class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <p
-              class="MuiTypography-root MuiTypography-body1 sc-jXbUNf EWGa css-rizt0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 sc-qdQOe kgMyIU css-rizt0-MuiTypography-root"
             >
               visualizationSettings.showDataPoints
             </p>

--- a/PxGraf.Frontend/src/views/Editor/__snapshots__/Editor.test.tsx.snap
+++ b/PxGraf.Frontend/src/views/Editor/__snapshots__/Editor.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`Rendering test renders correctly 1`] = `
   class="MuiStack-root css-m69qwo-MuiStack-root"
 >
   <div
-    class="sc-eDPEui kyvpOY MuiBox-root css-ve9ogo"
+    class="sc-folSZX isdgta MuiBox-root css-ve9ogo"
   >
     <div
-      class="sc-jEACwF hfpDnV"
+      class="sc-bqqMSY caqzcx"
     >
       <p
         class="MuiTypography-root MuiTypography-body2 css-1wle3ir-MuiTypography-root"
@@ -18,7 +18,7 @@ exports[`Rendering test renders correctly 1`] = `
       </p>
       <button
         aria-label="tooltip.open: variableSelect.title"
-        class="sc-dAlyuI irRRBj"
+        class="sc-iqkkDd dZtsC"
         id="mainContent"
       >
         <svg
@@ -35,7 +35,7 @@ exports[`Rendering test renders correctly 1`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-dLMFT bSWlSE css-1808mag-MuiPaper-root-MuiAccordion-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-hCcPtG gjYMFl css-1808mag-MuiPaper-root-MuiAccordion-root"
       style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
     >
       <h3
@@ -92,13 +92,13 @@ exports[`Rendering test renders correctly 1`] = `
               role="region"
             >
               <div
-                class="MuiAccordionDetails-root sc-cPiKLY jYkpdy css-1lj39kh-MuiAccordionDetails-root"
+                class="MuiAccordionDetails-root sc-krVzYl jEIFev css-1lj39kh-MuiAccordionDetails-root"
               >
                 <div
-                  class="MuiStack-root sc-kpDqfp bBTtYc css-1sazv7p-MuiStack-root"
+                  class="MuiStack-root sc-kEbgWM cjPnPc css-1sazv7p-MuiStack-root"
                 >
                   <div
-                    class="MuiStack-root sc-dhKdcy bEdgEi css-m69qwo-MuiStack-root"
+                    class="MuiStack-root sc-jrIDTr eeuQxt css-m69qwo-MuiStack-root"
                   >
                     <span
                       aria-label="variableSelect.openMenu"
@@ -120,7 +120,7 @@ exports[`Rendering test renders correctly 1`] = `
                       </svg>
                     </span>
                     <div
-                      class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon sc-iGgWBk eZCLgH css-o5oj2-MuiAutocomplete-root"
+                      class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon sc-jSppWd iJXiSX css-o5oj2-MuiAutocomplete-root"
                     >
                       <div
                         class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"

--- a/PxGraf.Frontend/src/views/Editor/__snapshots__/EditorFilterSection.test.tsx.snap
+++ b/PxGraf.Frontend/src/views/Editor/__snapshots__/EditorFilterSection.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-eDPEui bsOVGY MuiBox-root css-0"
+    class="sc-folSZX bPmpFG MuiBox-root css-0"
   >
     <div
-      class="sc-jEACwF hfpDnV"
+      class="sc-bqqMSY caqzcx"
     >
       <p
         class="MuiTypography-root MuiTypography-body2 css-1wle3ir-MuiTypography-root"
@@ -15,7 +15,7 @@ exports[`Rendering test renders correctly 1`] = `
       </p>
       <button
         aria-label="tooltip.open: variableSelect.title"
-        class="sc-dAlyuI irRRBj"
+        class="sc-iqkkDd dZtsC"
         id="mainContent"
       >
         <svg
@@ -32,7 +32,7 @@ exports[`Rendering test renders correctly 1`] = `
       </button>
     </div>
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-dLMFT bSWlSE css-1808mag-MuiPaper-root-MuiAccordion-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters sc-hCcPtG gjYMFl css-1808mag-MuiPaper-root-MuiAccordion-root"
       style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
     >
       <h3
@@ -89,13 +89,13 @@ exports[`Rendering test renders correctly 1`] = `
               role="region"
             >
               <div
-                class="MuiAccordionDetails-root sc-cPiKLY jYkpdy css-1lj39kh-MuiAccordionDetails-root"
+                class="MuiAccordionDetails-root sc-krVzYl jEIFev css-1lj39kh-MuiAccordionDetails-root"
               >
                 <div
-                  class="MuiStack-root sc-kpDqfp bBTtYc css-1sazv7p-MuiStack-root"
+                  class="MuiStack-root sc-kEbgWM cjPnPc css-1sazv7p-MuiStack-root"
                 >
                   <div
-                    class="MuiStack-root sc-dhKdcy bEdgEi css-m69qwo-MuiStack-root"
+                    class="MuiStack-root sc-jrIDTr eeuQxt css-m69qwo-MuiStack-root"
                   >
                     <span
                       aria-label="variableSelect.openMenu"
@@ -117,7 +117,7 @@ exports[`Rendering test renders correctly 1`] = `
                       </svg>
                     </span>
                     <div
-                      class="sc-gsFSXt iOsDE MuiBox-root css-0"
+                      class="sc-gKkgUA gfREpc MuiBox-root css-0"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
@@ -127,7 +127,7 @@ exports[`Rendering test renders correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiStack-root sc-dcJsrX kBjfng css-nen11g-MuiStack-root"
+                    class="MuiStack-root sc-eCQgVK ehigaw css-nen11g-MuiStack-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
@@ -135,10 +135,10 @@ exports[`Rendering test renders correctly 1`] = `
                       general.results:
                     </p>
                     <ul
-                      class="MuiList-root MuiList-padding MuiList-dense sc-aXZVf gta-dsx css-st2ob2-MuiList-root"
+                      class="MuiList-root MuiList-padding MuiList-dense sc-bdDsCe lcgotI css-st2ob2-MuiList-root"
                     >
                       <li
-                        class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+                        class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
                       >
                         <div
                           class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -151,7 +151,7 @@ exports[`Rendering test renders correctly 1`] = `
                         </div>
                       </li>
                       <li
-                        class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+                        class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
                       >
                         <div
                           class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -164,7 +164,7 @@ exports[`Rendering test renders correctly 1`] = `
                         </div>
                       </li>
                       <li
-                        class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gEvEes ehFqxO css-qyw6ft-MuiListItem-root"
+                        class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding sc-gtcBCx hlejmV css-qyw6ft-MuiListItem-root"
                       >
                         <div
                           class="MuiListItemText-root MuiListItemText-dense css-1suf81v-MuiListItemText-root"
@@ -212,7 +212,7 @@ exports[`Rendering test renders correctly 1`] = `
                     </label>
                   </div>
                   <div
-                    class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon sc-jXbUNf OzPMv css-1tlcqt-MuiAutocomplete-root"
+                    class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon sc-qdQOe eGuQwZ css-1tlcqt-MuiAutocomplete-root"
                   >
                     <div
                       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"

--- a/PxGraf.Frontend/src/views/Editor/__snapshots__/EditorFooterSection.test.tsx.snap
+++ b/PxGraf.Frontend/src/views/Editor/__snapshots__/EditorFooterSection.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-fqkvVO fLrQyP MuiBox-root css-0"
+    class="sc-hKVpXn htunVG MuiBox-root css-0"
   >
     <button
       aria-label="tooltip.open: editor.save"
-      class="sc-aXZVf linXBE"
+      class="sc-bdDsCe fVRDsd"
     >
       <svg
         aria-hidden="true"

--- a/PxGraf.Frontend/src/views/Editor/__snapshots__/EditorMetaSection.test.tsx.snap
+++ b/PxGraf.Frontend/src/views/Editor/__snapshots__/EditorMetaSection.test.tsx.snap
@@ -3,22 +3,22 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-hzhJZP lndpKx MuiBox-root css-0"
+    class="sc-fKwzVe gwlFvx MuiBox-root css-0"
   >
     <div
-      class="sc-fHjqPg fFsfjJ MuiBox-root css-1mc6bnb"
+      class="sc-bCgoVd jbAaJp MuiBox-root css-1mc6bnb"
     >
       <div
-        class="sc-kOHTFy gMqbCq"
+        class="sc-ikBzZv jNwkba"
       >
         <p
-          class="MuiTypography-root MuiTypography-body2 sc-hmdomR crmwcA css-1wle3ir-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body2 sc-ivKqQM crquHl css-1wle3ir-MuiTypography-root"
         >
           editor.contentLanguage
         </p>
         <button
           aria-label="tooltip.open: editor.contentLanguage"
-          class="sc-gsFSXt jMCyKe"
+          class="sc-gKkgUA iAMuGy"
         >
           <svg
             aria-hidden="true"
@@ -48,7 +48,7 @@ exports[`Rendering test renders correctly 1`] = `
               aria-controls="simple-tabpanel-fi"
               aria-label="editor.contentLanguage: lang.local.fi"
               aria-selected="true"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected sc-bXCLTF gDihUm css-g7p0lk-MuiButtonBase-root-MuiTab-root"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected sc-cxxQMU efXSxa css-g7p0lk-MuiButtonBase-root-MuiTab-root"
               id="simple-tab-fi"
               role="tab"
               tabindex="0"
@@ -60,7 +60,7 @@ exports[`Rendering test renders correctly 1`] = `
               aria-controls="simple-tabpanel-sv"
               aria-label="editor.contentLanguage: lang.local.sv"
               aria-selected="false"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary sc-bXCLTF gDihUm css-g7p0lk-MuiButtonBase-root-MuiTab-root"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary sc-cxxQMU efXSxa css-g7p0lk-MuiButtonBase-root-MuiTab-root"
               id="simple-tab-sv"
               role="tab"
               tabindex="-1"
@@ -72,7 +72,7 @@ exports[`Rendering test renders correctly 1`] = `
               aria-controls="simple-tabpanel-en"
               aria-label="editor.contentLanguage: lang.local.en"
               aria-selected="false"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary sc-bXCLTF gDihUm css-g7p0lk-MuiButtonBase-root-MuiTab-root"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary sc-cxxQMU efXSxa css-g7p0lk-MuiButtonBase-root-MuiTab-root"
               id="simple-tab-en"
               role="tab"
               tabindex="-1"
@@ -89,7 +89,7 @@ exports[`Rendering test renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-jsJBEQ eUSjhz MuiBox-root css-0"
+      class="sc-llQYOh dVfrIY MuiBox-root css-0"
     >
       <div
         aria-labelledby="simple-tab-fi"
@@ -97,20 +97,20 @@ exports[`Rendering test renders correctly 1`] = `
         role="tabpanel"
       >
         <div
-          class="sc-aXZVf eSKBbS MuiBox-root css-0"
+          class="sc-bdDsCe ewwDVL MuiBox-root css-0"
         >
           <div
-            class="sc-kpDqfp kCKSnF MuiBox-root css-0"
+            class="sc-kEbgWM jqaMqF MuiBox-root css-0"
           >
             <div
-              class="sc-dhKdcy elZQdn"
+              class="sc-jrIDTr gVSSYU"
             >
               <div
-                class="sc-jXbUNf cEYnqm"
+                class="sc-qdQOe jOquNE"
               >
                 <button
                   aria-label="tooltip.open: editMetadata.header"
-                  class="sc-gsFSXt jMCyKe"
+                  class="sc-gKkgUA iAMuGy"
                 >
                   <svg
                     aria-hidden="true"
@@ -136,7 +136,7 @@ exports[`Rendering test renders correctly 1`] = `
                     editMetadata.header
                   </label>
                   <div
-                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gEvEes imPffV css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtcBCx Dusne css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
                   >
                     <input
                       aria-invalid="false"
@@ -165,14 +165,14 @@ exports[`Rendering test renders correctly 1`] = `
               </div>
             </div>
             <div
-              class="sc-cPiKLY hbJcxi"
+              class="sc-krVzYl jzidJz"
             >
               <div
-                class="sc-jEACwF jclZoL"
+                class="sc-bqqMSY itQibn"
               >
                 <button
                   aria-label="tooltip.open: editMetadata.editorTitle"
-                  class="sc-gsFSXt jMCyKe"
+                  class="sc-gKkgUA iAMuGy"
                 >
                   <svg
                     aria-hidden="true"
@@ -187,7 +187,7 @@ exports[`Rendering test renders correctly 1`] = `
                   </svg>
                 </button>
                 <div
-                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters sc-dAlyuI cPIluc css-1808mag-MuiPaper-root-MuiAccordion-root"
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters sc-iqkkDd gMOKrp css-1808mag-MuiPaper-root-MuiAccordion-root"
                   style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
                 >
                   <h3
@@ -245,10 +245,10 @@ exports[`Rendering test renders correctly 1`] = `
                           role="region"
                         >
                           <div
-                            class="MuiAccordionDetails-root sc-dLMFT frypaN css-1lj39kh-MuiAccordionDetails-root"
+                            class="MuiAccordionDetails-root sc-hCcPtG rnJdY css-1lj39kh-MuiAccordionDetails-root"
                           >
                             <div
-                              class="sc-jlZhev hxqCKM MuiBox-root css-1mc6bnb"
+                              class="sc-crPgjm bHMEA-D MuiBox-root css-1mc6bnb"
                             >
                               <div
                                 class="MuiTabs-root css-jhczcq-MuiTabs-root"
@@ -292,7 +292,7 @@ exports[`Rendering test renders correctly 1`] = `
                               </div>
                             </div>
                             <div
-                              class="sc-cwHptO fjpGx MuiBox-root css-0"
+                              class="sc-dYjPD KvxZA MuiBox-root css-0"
                             >
                               <div
                                 aria-labelledby="simple-tab-0"
@@ -300,7 +300,7 @@ exports[`Rendering test renders correctly 1`] = `
                                 role="tabpanel"
                               >
                                 <div
-                                  class="sc-aXZVf eSKBbS MuiBox-root css-0"
+                                  class="sc-bdDsCe ewwDVL MuiBox-root css-0"
                                 >
                                   <div
                                     class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row MuiGrid-spacing-xs-3 css-1u8xl8z-MuiGrid-root"
@@ -312,7 +312,7 @@ exports[`Rendering test renders correctly 1`] = `
                                         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-i9zgug-MuiPaper-root"
                                       >
                                         <div
-                                          class="MuiStack-root sc-eqUAAB bIpVLn css-1sazv7p-MuiStack-root"
+                                          class="MuiStack-root sc-dkXsAU bZeLrJ css-1sazv7p-MuiStack-root"
                                         >
                                           <div
                                             class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
@@ -325,7 +325,7 @@ exports[`Rendering test renders correctly 1`] = `
                                               editMetadata.valueName: fgfgfg1
                                             </label>
                                             <div
-                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gEvEes imPffV css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtcBCx Dusne css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
                                             >
                                               <input
                                                 aria-invalid="false"
@@ -362,7 +362,7 @@ exports[`Rendering test renders correctly 1`] = `
                                               editMetadata.unit
                                             </label>
                                             <div
-                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gEvEes imPffV css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtcBCx Dusne css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
                                             >
                                               <input
                                                 aria-invalid="false"
@@ -399,7 +399,7 @@ exports[`Rendering test renders correctly 1`] = `
                                               editMetadata.source
                                             </label>
                                             <div
-                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gEvEes imPffV css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtcBCx Dusne css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
                                             >
                                               <input
                                                 aria-invalid="false"
@@ -435,7 +435,7 @@ exports[`Rendering test renders correctly 1`] = `
                                         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-i9zgug-MuiPaper-root"
                                       >
                                         <div
-                                          class="MuiStack-root sc-eqUAAB bIpVLn css-1sazv7p-MuiStack-root"
+                                          class="MuiStack-root sc-dkXsAU bZeLrJ css-1sazv7p-MuiStack-root"
                                         >
                                           <div
                                             class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
@@ -448,7 +448,7 @@ exports[`Rendering test renders correctly 1`] = `
                                               editMetadata.valueName: fgfgfg2
                                             </label>
                                             <div
-                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gEvEes imPffV css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtcBCx Dusne css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
                                             >
                                               <input
                                                 aria-invalid="false"
@@ -485,7 +485,7 @@ exports[`Rendering test renders correctly 1`] = `
                                               editMetadata.unit
                                             </label>
                                             <div
-                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gEvEes imPffV css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtcBCx Dusne css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
                                             >
                                               <input
                                                 aria-invalid="false"
@@ -522,7 +522,7 @@ exports[`Rendering test renders correctly 1`] = `
                                               editMetadata.source
                                             </label>
                                             <div
-                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gEvEes imPffV css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+                                              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl sc-gtcBCx Dusne css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
                                             >
                                               <input
                                                 aria-invalid="false"
@@ -586,17 +586,17 @@ exports[`Rendering test renders correctly 1`] = `
       />
     </div>
     <div
-      class="sc-koXPm eANAXt"
+      class="sc-giQkEn dufkIK"
     >
       <div
-        class="sc-bmzYkV hbLjAQ"
+        class="sc-ezjgic dymapY"
       >
         <div
-          class="sc-dtBdUn cYvHYr"
+          class="sc-kLEbxe fTMQqS"
         >
           <button
             aria-label="tooltip.open: tooltip.visualizationType"
-            class="sc-gsFSXt jMCyKe"
+            class="sc-gKkgUA iAMuGy"
           >
             <svg
               aria-hidden="true"
@@ -611,7 +611,7 @@ exports[`Rendering test renders correctly 1`] = `
             </svg>
           </button>
           <div
-            class="sc-iHGNWg ibEeme"
+            class="sc-bYgEKt jZRdrB"
           >
             <div
               aria-label="tooltip.visualizationType"
@@ -657,7 +657,7 @@ exports[`Rendering test renders correctly 1`] = `
           </button>
         </div>
         <div
-          class="sc-dtBdUn cYvHYr"
+          class="sc-kLEbxe fTMQqS"
         >
           <div
             aria-live="polite"
@@ -695,7 +695,7 @@ exports[`Rendering test renders correctly 1`] = `
     <div>
       <button
         aria-label="tooltip.open: tooltip.visualizationConfig"
-        class="sc-gsFSXt jMCyKe"
+        class="sc-gKkgUA iAMuGy"
       >
         <svg
           aria-hidden="true"
@@ -710,7 +710,7 @@ exports[`Rendering test renders correctly 1`] = `
         </svg>
       </button>
       <div
-        class="sc-fUnMCe jyYBph"
+        class="sc-kgohyr jhnUFu"
       >
         <div
           class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
@@ -769,7 +769,7 @@ exports[`Rendering test renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="MuiStack-root sc-gFqAkO jjjJaL css-m69qwo-MuiStack-root"
+          class="MuiStack-root sc-ieCSdj cGvxcV css-m69qwo-MuiStack-root"
         >
           <div
             class="MuiBox-root css-0"
@@ -781,7 +781,7 @@ exports[`Rendering test renders correctly 1`] = `
               chartSettings.markerScale
             </p>
             <span
-              class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-ikkxIz bTpGly css-1e45yg4-MuiSlider-root"
+              class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeMedium sc-dILkzW gMLFUC css-1e45yg4-MuiSlider-root"
             >
               <span
                 class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -868,7 +868,7 @@ exports[`Rendering test renders correctly 1`] = `
         </div>
       </div>
       <div
-        class="sc-fUnMCe jyYBph"
+        class="sc-kgohyr jhnUFu"
       >
         <div
           class="MuiFormControl-root MuiFormControl-fullWidth css-ytlejw-MuiFormControl-root"
@@ -899,7 +899,7 @@ exports[`Rendering test renders correctly 1`] = `
               class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
             >
               <p
-                class="MuiTypography-root MuiTypography-body1 sc-feUZmx iWcaEC css-rizt0-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 sc-dlwHGs kWdQMd css-rizt0-MuiTypography-root"
               >
                 chartSettings.cutYAxis
               </p>
@@ -907,7 +907,7 @@ exports[`Rendering test renders correctly 1`] = `
           </label>
         </div>
         <div
-          class="MuiFormControl-root MuiFormControl-fullWidth sc-dAbbOM ieAEGS css-ytlejw-MuiFormControl-root"
+          class="MuiFormControl-root MuiFormControl-fullWidth sc-hHopjF eriYyn css-ytlejw-MuiFormControl-root"
         >
           <label
             class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
@@ -935,7 +935,7 @@ exports[`Rendering test renders correctly 1`] = `
               class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
             >
               <p
-                class="MuiTypography-root MuiTypography-body1 sc-feUZmx iWcaEC css-rizt0-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 sc-dlwHGs kWdQMd css-rizt0-MuiTypography-root"
               >
                 chartSettings.matchXLabelsToEnd
               </p>
@@ -971,7 +971,7 @@ exports[`Rendering test renders correctly 1`] = `
               class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
             >
               <p
-                class="MuiTypography-root MuiTypography-body1 sc-feUZmx iWcaEC css-rizt0-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 sc-dlwHGs kWdQMd css-rizt0-MuiTypography-root"
               >
                 visualizationSettings.showDataPoints
               </p>

--- a/PxGraf.Frontend/src/views/Editor/__snapshots__/EditorPreviewSection.test.tsx.snap
+++ b/PxGraf.Frontend/src/views/Editor/__snapshots__/EditorPreviewSection.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-  class="sc-gsFSXt hnOWcO MuiBox-root css-0"
+  class="sc-gKkgUA iiaLWm MuiBox-root css-0"
 >
   <div
-    class="sc-dcJsrX cvUQts"
+    class="sc-eCQgVK hDcoKs"
   >
     <button
       aria-label="tooltip.open: tooltip.visualizationSize"
-      class="sc-aXZVf linXBE"
+      class="sc-bdDsCe fVRDsd"
     >
       <svg
         aria-hidden="true"
@@ -109,7 +109,7 @@ exports[`Rendering test renders correctly 1`] = `
     class="MuiStack-root css-pl8gqh-MuiStack-root"
   />
   <div
-    class="sc-iGgWBk fvSpmY tk-table"
+    class="sc-jSppWd cEFcHx tk-table"
   >
     <pre
       data-testid="Chart"
@@ -124,7 +124,7 @@ exports[`Rendering test renders correctly 1`] = `
 exports[`Rendering test renders correctly with no valid visualizations 1`] = `
 <DocumentFragment>
   <div
-  class="sc-kAycey jMuiuH"
+  class="sc-iCECmn KaRKN"
 >
   <span>
     previewGuide.impossibleToVisualize
@@ -136,7 +136,7 @@ exports[`Rendering test renders correctly with no valid visualizations 1`] = `
 exports[`Rendering test renders correctly with no valid visualizations or rejected visualizations 1`] = `
 <DocumentFragment>
   <div
-  class="sc-kAycey jMuiuH"
+  class="sc-iCECmn KaRKN"
 >
   <span>
     previewGuide.tooSmallQuery

--- a/PxGraf.Frontend/src/views/TableListSelection/__snapshots__/TableListSelection.test.tsx.snap
+++ b/PxGraf.Frontend/src/views/TableListSelection/__snapshots__/TableListSelection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthMd sc-fTFjTL bVgelF css-u4uvlt-MuiContainer-root"
+    class="MuiContainer-root MuiContainer-maxWidthMd sc-eGZRwK csuuOE css-u4uvlt-MuiContainer-root"
   >
     <ul
       class="MuiList-root MuiList-padding css-nqrrgh-MuiList-root"

--- a/PxGraf.Frontend/src/views/TableTreeSelection/__snapshots__/TableTreeSelection.test.tsx.snap
+++ b/PxGraf.Frontend/src/views/TableTreeSelection/__snapshots__/TableTreeSelection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering test renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthMd sc-hZDyAP geaGfF css-u4uvlt-MuiContainer-root"
+    class="MuiContainer-root MuiContainer-maxWidthMd sc-bXuqjq dFANML css-u4uvlt-MuiContainer-root"
   >
     <nav
       aria-labelledby="nested-list-subheader"
@@ -14,14 +14,14 @@ exports[`Rendering test renders correctly 1`] = `
         id="nested-list-subheader"
       >
         <div
-          class="sc-fTFjTL fwytmx"
+          class="sc-eGZRwK iJmkAk"
         >
           <div>
             tableSelect.title
           </div>
           <button
             aria-label="tooltip.open: tableSelect.title"
-            class="sc-dAlyuI irRRBj"
+            class="sc-iqkkDd dZtsC"
             id="mainContent"
           >
             <svg
@@ -39,7 +39,7 @@ exports[`Rendering test renders correctly 1`] = `
         </div>
       </div>
       <li
-        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-hwdzOS hqaYXP css-cfd5wn-MuiListItem-root"
+        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-jQQpTv jtbCSD css-cfd5wn-MuiListItem-root"
         id="id1.px"
       >
         <a
@@ -83,7 +83,7 @@ exports[`Rendering test renders correctly 1`] = `
         class="MuiDivider-root MuiDivider-fullWidth css-1jpc804-MuiDivider-root"
       />
       <li
-        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-hwdzOS hqaYXP css-cfd5wn-MuiListItem-root"
+        class="MuiListItem-root MuiListItem-gutters MuiListItem-padding sc-jQQpTv jtbCSD css-cfd5wn-MuiListItem-root"
         id="id2.px"
       >
         <a

--- a/PxGraf/PxGraf.csproj
+++ b/PxGraf/PxGraf.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>PxGraf</AssemblyName>
     <UserSecretsId>5fefcbdc-e04e-4475-9927-aab412b027ff</UserSecretsId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>4.8.3</VersionPrefix>
+    <VersionPrefix>4.8.4</VersionPrefix>
 	<SpaRoot>..\PxGraf.Frontend</SpaRoot>
 	<Configurations>Debug;Release;Test</Configurations>
   </PropertyGroup>

--- a/PxGraf/Utility/SqFileInterface.cs
+++ b/PxGraf/Utility/SqFileInterface.cs
@@ -61,7 +61,7 @@ namespace PxGraf.Utility
         /// </summary>
         public async Task<SavedQuery> ReadSavedQueryFromFile(string id, string savedQueryDirectory)
         {
-            if(!InputValidation.ValidateSqIdString(id)) throw new ArgumentException("The provided id is not a valid saved query id string.");
+            if(!InputValidation.ValidateSqIdString(id)) throw new ArgumentException("The provided id is not a valid saved query id string.", nameof(id));
             string filePath = savedQueryStorage.CombinePath(savedQueryDirectory, id + ".sq");
             return await lockScope.RunLockedAsync(
                 filePath,
@@ -74,7 +74,7 @@ namespace PxGraf.Utility
         /// </summary>
         public async Task<ArchiveCube> ReadArchiveCubeFromFile(string id, string archiveDirectory)
         {
-            if(!InputValidation.ValidateSqIdString(id)) throw new ArgumentException("The provided id is not a valid saved query id string.");
+            if(!InputValidation.ValidateSqIdString(id)) throw new ArgumentException("The provided id is not a valid archive file id string.", nameof(id));
             string filePath = archiveStorage.CombinePath(archiveDirectory, id + ".sqa");
             return await lockScope.RunLockedAsync(
                 filePath,

--- a/PxGraf/Utility/SqFileInterface.cs
+++ b/PxGraf/Utility/SqFileInterface.cs
@@ -61,6 +61,7 @@ namespace PxGraf.Utility
         /// </summary>
         public async Task<SavedQuery> ReadSavedQueryFromFile(string id, string savedQueryDirectory)
         {
+            if(!InputValidation.ValidateSqIdString(id)) throw new ArgumentException("The provided id is not a valid saved query id string.");
             string filePath = savedQueryStorage.CombinePath(savedQueryDirectory, id + ".sq");
             return await lockScope.RunLockedAsync(
                 filePath,
@@ -73,6 +74,7 @@ namespace PxGraf.Utility
         /// </summary>
         public async Task<ArchiveCube> ReadArchiveCubeFromFile(string id, string archiveDirectory)
         {
+            if(!InputValidation.ValidateSqIdString(id)) throw new ArgumentException("The provided id is not a valid saved query id string.");
             string filePath = archiveStorage.CombinePath(archiveDirectory, id + ".sqa");
             return await lockScope.RunLockedAsync(
                 filePath,

--- a/PxGraf/nlog.config
+++ b/PxGraf/nlog.config
@@ -43,10 +43,11 @@
 	</targets>
 
 	<rules>
-		<!-- Audit logs go to the audit target (only when AuditLog.Enabled=true) -->
+		<!-- Audit logs go to the audit target (only when AuditLog.Enabled=true and Folder is set) -->
 		<logger name="PxGraf.Services.AuditLogService" minlevel="Info" writeTo="audit" final="true">
 			<filters defaultAction="Log">
 				<when condition="'${lowercase:${configsetting:item=LogOptions.AuditLog.Enabled:default=false}}' != 'true'" action="Ignore" />
+				<when condition="'${configsetting:item=LogOptions.Folder}' == ''" action="Ignore" />
 			</filters>
 		</logger>
 		

--- a/PxGraf/nlog.config
+++ b/PxGraf/nlog.config
@@ -5,19 +5,17 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       autoReload="true"
       internalLogLevel="Info"
-      internalLogFile="${configsetting:item=LogOptions.Folder}\internal-nlog-AspNetCore.txt">
+      internalLogFile="${basedir}/internal-nlog-AspNetCore.txt">
 	
 	<extensions>
 		<add assembly="NLog.Web.AspNetCore"/>
 	</extensions>
 
 	<variable name="logsPath" value="${configsetting:item=LogOptions.Folder}" />
-	<variable name="textLogEnabled" value="${when:when='${configsetting:item=LogOptions.Folder}'!='':inner=true:else=false}" />
-	<variable name="auditEnabled" value="${configsetting:item=LogOptions.AuditLog.Enabled:default=false}" />
 	
 	<targets>
 		<!-- Regular application logs -->
-		<target xsi:type="File" name="own" filename="${var:logsPath}\nlog-${shortdate}.log" >
+		<target xsi:type="File" name="own" filename="${var:logsPath}/nlog-${shortdate}.log" >
 			<layout xsi:type="JsonLayout" includeAllProperties="true" maxRecursionLimit="10" indentJson="true" >
 				<attribute name="Sysid" layout="${configsetting:item=LogOptions.SysId}" />
 				<attribute name="Status" layout="${environment:ASPNETCORE_ENVIRONMENT}" />
@@ -27,8 +25,12 @@
 			</layout>
 		</target>
 		
+		<!-- Console output for development -->
+		<target xsi:type="ColoredConsole" name="console"
+			layout="${longdate} [${level:upperCase=true}] ${logger:shortName=true} - ${message}${exception:format=ToString}" />
+		
 		<!-- Dedicated target for audit logs -->
-		<target xsi:type="File" name="audit" filename="${var:logsPath}\audit-${shortdate}.log">
+		<target xsi:type="File" name="audit" filename="${var:logsPath}/audit-${shortdate}.log">
 			<layout xsi:type="JsonLayout" includeAllProperties="true" maxRecursionLimit="10" indentJson="true">
 				<attribute name="Sysid" layout="${configsetting:item=LogOptions.SysId}" />
 				<attribute name="Datetime" layout="${longdate}" />
@@ -41,16 +43,29 @@
 	</targets>
 
 	<rules>
-		<!-- Audit logs go to the audit target -->
-		<logger name="PxGraf.Services.AuditLogService" minlevel="Info" writeTo="audit" 
-			enabled="${when:when='${auditEnabled}'=='true'}" final="true" />
+		<!-- Audit logs go to the audit target (only when AuditLog.Enabled=true) -->
+		<logger name="PxGraf.Services.AuditLogService" minlevel="Info" writeTo="audit" final="true">
+			<filters defaultAction="Log">
+				<when condition="'${lowercase:${configsetting:item=LogOptions.AuditLog.Enabled:default=false}}' != 'true'" action="Ignore" />
+			</filters>
+		</logger>
 		
 		<!-- Skip Microsoft and System logs -->
 		<logger name="Microsoft.*" maxlevel="Fatal" final="true" />
 		<logger name="System.Net.Http.*" maxlevel="Fatal" final="true" />
 
-		<!-- All other logs go to the regular target -->
-		<logger name="*" minlevel="${configsetting:item=LogOptions.Level}" writeTo="own" 
-				enabled="${when:when='${textLogEnabled}'=='true'}"/>
+		<!-- Console output in Development environment -->
+		<logger name="*" minlevel="${configsetting:item=LogOptions.Level}" writeTo="console">
+			<filters defaultAction="Log">
+				<when condition="'${environment:ASPNETCORE_ENVIRONMENT}' != 'Development'" action="Ignore" />
+			</filters>
+		</logger>
+
+		<!-- All other logs go to the regular target (only when LogOptions.Folder is set) -->
+		<logger name="*" minlevel="${configsetting:item=LogOptions.Level}" writeTo="own">
+			<filters defaultAction="Log">
+				<when condition="'${configsetting:item=LogOptions.Folder}' == ''" action="Ignore" />
+			</filters>
+		</logger>
 	</rules>
 </nlog>

--- a/UnitTests/UtilityFunctionsTests/InputValidationTests.cs
+++ b/UnitTests/UtilityFunctionsTests/InputValidationTests.cs
@@ -66,6 +66,70 @@ namespace UnitTests.UtilityFunctionsTests
             Assert.That(InputValidation.ValidateSqIdString(null), Is.False);
         }
 
+        // Path traversal attempts
+        [Test]
+        public void InvalidSqId_DotDotSlashTraversalTest()
+        {
+            Assert.That(InputValidation.ValidateSqIdString("../../../etc/passwd"), Is.False);
+        }
+
+        [Test]
+        public void InvalidSqId_DotDotBackslashTraversalTest()
+        {
+            Assert.That(InputValidation.ValidateSqIdString("..\\..\\windows\\system32"), Is.False);
+        }
+
+        [Test]
+        public void InvalidSqId_UrlEncodedTraversalTest()
+        {
+            // %2e%2e%2f is URL-encoded ../
+            Assert.That(InputValidation.ValidateSqIdString("%2e%2e%2fetc%2fpasswd"), Is.False);
+        }
+
+        [Test]
+        public void InvalidSqId_AbsoluteUnixPathTest()
+        {
+            Assert.That(InputValidation.ValidateSqIdString("/etc/passwd"), Is.False);
+        }
+
+        [Test]
+        public void InvalidSqId_NullByteTraversalTest()
+        {
+            // Null byte injection can truncate strings in some contexts
+            Assert.That(InputValidation.ValidateSqIdString("a3af0d90-eeeb-4840-bc14-87f53bc7c8fe\0.txt"), Is.False);
+        }
+
+        // Injection attempts
+        [Test]
+        public void InvalidSqId_SqlInjectionTest()
+        {
+            Assert.That(InputValidation.ValidateSqIdString("a3af0d90'; DROP TABLE saved_queries--"), Is.False);
+        }
+
+        [Test]
+        public void InvalidSqId_CommandInjectionTest()
+        {
+            Assert.That(InputValidation.ValidateSqIdString("a3af0d90; rm -rf /"), Is.False);
+        }
+
+        [Test]
+        public void InvalidSqId_CrlfInjectionTest()
+        {
+            Assert.That(InputValidation.ValidateSqIdString("a3af0d90-eeeb\r\nX-Header: injected"), Is.False);
+        }
+
+        [Test]
+        public void InvalidSqId_XssInjectionTest()
+        {
+            Assert.That(InputValidation.ValidateSqIdString("<script>alert(1)</script>"), Is.False);
+        }
+
+        [Test]
+        public void InvalidSqId_TemplateInjectionTest()
+        {
+            Assert.That(InputValidation.ValidateSqIdString("{{7*7}}"), Is.False);
+        }
+
         [Test]
         public void ValidFilePathPartTest()
         {

--- a/UnitTests/UtilityFunctionsTests/InputValidationTests.cs
+++ b/UnitTests/UtilityFunctionsTests/InputValidationTests.cs
@@ -95,8 +95,9 @@ namespace UnitTests.UtilityFunctionsTests
         [Test]
         public void InvalidSqId_NullByteTraversalTest()
         {
-            // Null byte injection can truncate strings in some contexts
-            Assert.That(InputValidation.ValidateSqIdString("a3af0d90-eeeb-4840-bc14-87f53bc7c8fe\0.txt"), Is.False);
+            // Null byte injection can truncate strings in some contexts.
+            // Input is otherwise a valid SqId to specifically test null-byte rejection.
+            Assert.That(InputValidation.ValidateSqIdString("a3af0d90-eeeb-4840-bc14-87f53bc7c8fe\0"), Is.False);
         }
 
         // Injection attempts


### PR DESCRIPTION
Security:
- Add path traversal and injection test cases to ValidateSqIdString (dot-dot, backslash, URL-encoded, absolute path, null byte, SQL, shell, CRLF, XSS, template injection)
- Add ValidateSqIdString guard to ReadSavedQueryFromFile and ReadArchiveCubeFromFile in SqFileInterface

Frontend:
- Fix 6 moderate npm vulnerabilities (brace-expansion, postcss, ws, uuid via jest-junit upgrade to v17)
- Update 64 snapshots to reflect new MUI/styled-components class name hashes

NLog:
- Fix internalLogFile using ${basedir} instead of unresolvable ${configsetting:...} (config not yet loaded at that point)
- Replace broken enabled="${when:...}" attributes with <filters> blocks; NLog 6 does not evaluate layout renderers in the enabled attribute
- Fix audit log enabled check by wrapping with ${lowercase:...} to handle .NET bool.ToString() returning "True" instead of "true"
- Add ColoredConsole target for Development environment, filtered after Microsoft/System skip rules